### PR TITLE
From KAN-46-BE-feat/favorities into dev : 장소, 회원 즐겨찾기

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -26,7 +26,7 @@ out/
 !**/src/main/**/out/
 !**/src/test/**/out/
 
-src/main/resources/application.properties
+application-dev.yml
 
 ### NetBeans ###
 /nbproject/private/

--- a/backend/src/main/java/com/meong9/backend/domain/like/controller/LikeController.java
+++ b/backend/src/main/java/com/meong9/backend/domain/like/controller/LikeController.java
@@ -1,0 +1,42 @@
+package com.meong9.backend.domain.like.controller;
+
+import com.meong9.backend.domain.like.service.LikeService;
+import com.meong9.backend.domain.member.entity.Member;
+import com.meong9.backend.domain.member.service.MemberService;
+import com.meong9.backend.domain.pension.entity.Pension;
+import com.meong9.backend.domain.place.entity.Place;
+import com.meong9.backend.global.auth.entity.MemberDetails;
+import com.meong9.backend.global.dto.CommonResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+@Slf4j
+public class LikeController {
+    private final LikeService likeService;
+    private final MemberService memberService;
+
+    @PostMapping("/likes/places/{placeId}")
+    public ResponseEntity<?> togglePlaceLike(@AuthenticationPrincipal MemberDetails memberDetails,@PathVariable Long placeId) {
+        Member member=memberDetails.member();
+        log.debug("회원 이메일 = {}", member.getEmail());
+        String message = likeService.togglePlaceLike(member, placeId);
+        return CommonResponse.created("success");
+    }
+
+    @PostMapping("/likes/pensions/{pensionId}")
+    public ResponseEntity<?> togglePensionLike(@AuthenticationPrincipal MemberDetails memberDetails, @PathVariable Long pensionId) {
+        Member member=memberDetails.member();
+        String message = likeService.togglePensionLike(member, pensionId);
+        return CommonResponse.created("success");
+    }
+
+}

--- a/backend/src/main/java/com/meong9/backend/domain/like/controller/LikeController.java
+++ b/backend/src/main/java/com/meong9/backend/domain/like/controller/LikeController.java
@@ -24,7 +24,7 @@ public class LikeController {
     private final LikeService likeService;
     private final MemberService memberService;
 
-    @PostMapping("/likes/places/{placeId}")
+    @PostMapping("/places/likes/{placeId}")
     public ResponseEntity<?> togglePlaceLike(@AuthenticationPrincipal MemberDetails memberDetails,@PathVariable Long placeId) {
         Member member=memberDetails.member();
         log.debug("회원 이메일 = {}", member.getEmail());
@@ -32,7 +32,7 @@ public class LikeController {
         return CommonResponse.created("success");
     }
 
-    @PostMapping("/likes/pensions/{pensionId}")
+    @PostMapping("/pensions/likes/{pensionId}")
     public ResponseEntity<?> togglePensionLike(@AuthenticationPrincipal MemberDetails memberDetails, @PathVariable Long pensionId) {
         Member member=memberDetails.member();
         String message = likeService.togglePensionLike(member, pensionId);

--- a/backend/src/main/java/com/meong9/backend/domain/like/controller/LikeController.java
+++ b/backend/src/main/java/com/meong9/backend/domain/like/controller/LikeController.java
@@ -27,16 +27,13 @@ public class LikeController {
     @PostMapping("/places/likes/{placeId}")
     public ResponseEntity<?> togglePlaceLike(@AuthenticationPrincipal MemberDetails memberDetails,@PathVariable Long placeId) {
         Member member=memberDetails.member();
-        log.debug("회원 이메일 = {}", member.getEmail());
-        String message = likeService.togglePlaceLike(member, placeId);
-        return CommonResponse.created("success");
+        return CommonResponse.created(likeService.togglePlaceLike(member, placeId));
     }
 
     @PostMapping("/pensions/likes/{pensionId}")
     public ResponseEntity<?> togglePensionLike(@AuthenticationPrincipal MemberDetails memberDetails, @PathVariable Long pensionId) {
         Member member=memberDetails.member();
-        String message = likeService.togglePensionLike(member, pensionId);
-        return CommonResponse.created("success");
+        return CommonResponse.created(likeService.togglePensionLike(member, pensionId));
     }
 
 }

--- a/backend/src/main/java/com/meong9/backend/domain/like/entity/Like.java
+++ b/backend/src/main/java/com/meong9/backend/domain/like/entity/Like.java
@@ -1,0 +1,24 @@
+package com.meong9.backend.domain.like.entity;
+
+import com.meong9.backend.domain.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access=AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+@Table(name = "likes")
+public class Like {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long likeId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+}

--- a/backend/src/main/java/com/meong9/backend/domain/like/entity/Like.java
+++ b/backend/src/main/java/com/meong9/backend/domain/like/entity/Like.java
@@ -8,10 +8,18 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn
 @NoArgsConstructor(access=AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Getter
-@Table(name = "likes")
+@Table(
+        name = "likes",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"member_id", "pension_id"}),
+                @UniqueConstraint(columnNames = {"member_id", "place_id"})
+        }
+)
 public class Like {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/meong9/backend/domain/like/entity/PensionLike.java
+++ b/backend/src/main/java/com/meong9/backend/domain/like/entity/PensionLike.java
@@ -1,0 +1,21 @@
+package com.meong9.backend.domain.like.entity;
+
+import com.meong9.backend.domain.member.entity.Member;
+import com.meong9.backend.domain.pension.entity.Pension;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@Entity
+@DiscriminatorValue("Pension")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PensionLike extends Like{
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "pension_id")
+    private Pension pension;
+
+    public PensionLike(Member member, Pension pension) {
+        super(null, member);
+        this.pension = pension;
+    }
+}

--- a/backend/src/main/java/com/meong9/backend/domain/like/entity/PlaceLike.java
+++ b/backend/src/main/java/com/meong9/backend/domain/like/entity/PlaceLike.java
@@ -1,0 +1,24 @@
+package com.meong9.backend.domain.like.entity;
+
+import com.meong9.backend.domain.member.entity.Member;
+import com.meong9.backend.domain.place.entity.Place;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@DiscriminatorValue("Place")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PlaceLike extends Like{
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "place_id")
+    private Place place;
+
+    public PlaceLike(Member member, Place place) {
+        super(null, member);
+        this.place = place;
+    }
+}

--- a/backend/src/main/java/com/meong9/backend/domain/like/repository/LikeRepository.java
+++ b/backend/src/main/java/com/meong9/backend/domain/like/repository/LikeRepository.java
@@ -1,0 +1,18 @@
+package com.meong9.backend.domain.like.repository;
+
+import com.meong9.backend.domain.like.entity.Like;
+import com.meong9.backend.domain.like.entity.PensionLike;
+import com.meong9.backend.domain.like.entity.PlaceLike;
+import com.meong9.backend.domain.member.entity.Member;
+import com.meong9.backend.domain.pension.entity.Pension;
+import com.meong9.backend.domain.place.entity.Place;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface LikeRepository extends JpaRepository<Like, Long> {
+    Optional<PlaceLike> findByMemberAndPlace(Member member, Place place);
+    Optional<PensionLike> findByMemberAndPension(Member member, Pension pension);
+}

--- a/backend/src/main/java/com/meong9/backend/domain/like/service/LikeService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/like/service/LikeService.java
@@ -1,0 +1,52 @@
+package com.meong9.backend.domain.like.service;
+
+import com.meong9.backend.domain.like.entity.PensionLike;
+import com.meong9.backend.domain.like.entity.PlaceLike;
+import com.meong9.backend.domain.like.repository.LikeRepository;
+import com.meong9.backend.domain.member.entity.Member;
+import com.meong9.backend.domain.pension.entity.Pension;
+import com.meong9.backend.domain.pension.repository.PensionRepository;
+import com.meong9.backend.domain.place.entity.Place;
+import com.meong9.backend.domain.place.repository.PlaceRepository;
+import com.meong9.backend.global.exception.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Service
+@RequiredArgsConstructor
+public class LikeService {
+    private final LikeRepository likeRepository;
+    private final PlaceRepository placeRepository;
+    private final PensionRepository pensionRepository;
+
+    @Transactional
+    public String togglePlaceLike(Member member, Long placeId) {
+        Place place=placeRepository.findById(placeId).orElseThrow(()->NotFoundException.entityNotFound("장소"));
+        return likeRepository.findByMemberAndPlace(member, place)
+                .map(like -> {
+                    likeRepository.delete(like);
+                    return "찜하기가 취소되었습니다.";
+                })
+                .orElseGet(() -> {
+                    likeRepository.save(new PlaceLike(member, place));
+                    return "찜하기가 등록되었습니다.";
+                });
+    }
+
+    @Transactional
+    public String togglePensionLike(Member member, Long pensionId) {
+        Pension pension=pensionRepository.findById(pensionId).orElseThrow(()->NotFoundException.entityNotFound("장소"));
+        return likeRepository.findByMemberAndPension(member, pension)
+                .map(like -> {
+                    likeRepository.delete(like);
+                    return "찜하기가 취소되었습니다.";
+                })
+                .orElseGet(() -> {
+                    likeRepository.save(new PensionLike(member, pension));
+                    return "찜하기가 등록되었습니다.";
+                });
+    }
+}

--- a/backend/src/main/java/com/meong9/backend/domain/like/service/LikeService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/like/service/LikeService.java
@@ -25,6 +25,7 @@ public class LikeService {
     @Transactional
     public String togglePlaceLike(Member member, Long placeId) {
         Place place=placeRepository.findById(placeId).orElseThrow(()->NotFoundException.entityNotFound("장소"));
+        place.increaseLikeCount();
         return likeRepository.findByMemberAndPlace(member, place)
                 .map(like -> {
                     likeRepository.delete(like);
@@ -39,6 +40,7 @@ public class LikeService {
     @Transactional
     public String togglePensionLike(Member member, Long pensionId) {
         Pension pension=pensionRepository.findById(pensionId).orElseThrow(()->NotFoundException.entityNotFound("장소"));
+        pension.increaseLikeCount();
         return likeRepository.findByMemberAndPension(member, pension)
                 .map(like -> {
                     likeRepository.delete(like);

--- a/backend/src/main/java/com/meong9/backend/domain/pension/entity/Pension.java
+++ b/backend/src/main/java/com/meong9/backend/domain/pension/entity/Pension.java
@@ -46,4 +46,11 @@ public class Pension {
 
     @Column(nullable = false)
     private Boolean isSoldOut = false;
+
+    @Column(nullable = false)
+    private Integer likeCount = 0;
+
+    public void increaseLikeCount(){
+        this.likeCount++;
+    }
 }

--- a/backend/src/main/java/com/meong9/backend/domain/pension/repository/PensionRepository.java
+++ b/backend/src/main/java/com/meong9/backend/domain/pension/repository/PensionRepository.java
@@ -1,0 +1,9 @@
+package com.meong9.backend.domain.pension.repository;
+
+import com.meong9.backend.domain.pension.entity.Pension;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PensionRepository extends JpaRepository<Pension, Long> {
+}

--- a/backend/src/main/java/com/meong9/backend/domain/place/entity/Place.java
+++ b/backend/src/main/java/com/meong9/backend/domain/place/entity/Place.java
@@ -6,6 +6,8 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
@@ -51,4 +53,8 @@ public class Place {
 
     @Column(nullable = false)
     private Integer likeCount = 0;
+
+    public void increaseLikeCount(){
+        this.likeCount++;
+    }
 }

--- a/backend/src/main/java/com/meong9/backend/domain/place/repository/PlaceRepository.java
+++ b/backend/src/main/java/com/meong9/backend/domain/place/repository/PlaceRepository.java
@@ -1,0 +1,9 @@
+package com.meong9.backend.domain.place.repository;
+
+import com.meong9.backend.domain.place.entity.Place;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PlaceRepository extends JpaRepository<Place, Long> {
+}

--- a/backend/src/main/resources/static/index.html
+++ b/backend/src/main/resources/static/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Kakao Login Test</title>
+    <script>
+        // Kakao 인증 요청 URL 구성
+        const REST_API_KEY = "f5073399aab84d115f651941e6f66e5c"; // 카카오 REST API 키로 변경
+        const REDIRECT_URI = "http://localhost:8080/api/v1/auth/callback/kakao"; // 콜백 URL로 변경
+
+        function loginWithKakao() {
+            const kakaoAuthUrl = `https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=${REST_API_KEY}&redirect_uri=${encodeURIComponent(REDIRECT_URI)}`;
+            window.location.href = kakaoAuthUrl; // Kakao 로그인 페이지로 리다이렉트
+        }
+    </script>
+</head>
+<body>
+<h1>Kakao Login Test</h1>
+<button onclick="loginWithKakao()">Login with Kakao</button>
+</body>
+</html>


### PR DESCRIPTION
## 📋 Summary
- 회원은 장소, 펜션을 즐겨찾기할 수 있다.

## ✨ Feature Details
| Method | Path                      | Description      |
|--------|---------------------------|------------------|
| POST   | /api/v1/places/likes/{placeId}|  장소 즐겨찾기     |
| POST   | /api/v1/pensions/likes/{pensionId} |  펜션 즐겨찾기     |

## 💡 Key Considerations
- likes 테이블 구조는 단일 테이블로 설계하고 DTYPE으로 시설 분류
- 참고자료: https://url.kr/5vepkr
- pk 전략은 조회 구현할 때 고민해봐야할듯

## ✅ Checklist
- [x] 코드를 스스로 검토했나요?
- [x] 필요한 테스트를 추가하고 모두 통과했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올렸나요?
- [x] 커밋 메시지가 컨벤션에 맞나요?
- [ ] 필요한 문서를 업데이트했나요?
