### PR TITLE
From KAN-19-BE-feat/getAndUpdateMemberInfo into dev

### DIFF
--- a/backend/src/main/java/com/meong9/backend/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/meong9/backend/domain/member/controller/MemberController.java
@@ -127,4 +127,13 @@ public class MemberController {
         UpdateMyPageResponseDto dto = memberService.updateMyPage(profileImage, requestDto, memberDetails.member());
         return CommonResponse.ok("success", dto);
     }
+
+    /**
+     * 선호 지역 조회 컨트롤러
+     */
+    @GetMapping("/members/interests/places")
+    public ResponseEntity<?> getPreferredRegions(@AuthenticationPrincipal MemberDetails memberDetails){
+        RegionDto dto = memberService.getPreferredRegions( memberDetails.member());
+        return CommonResponse.ok("success", dto);
+    }
 }

--- a/backend/src/main/java/com/meong9/backend/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/meong9/backend/domain/member/controller/MemberController.java
@@ -146,4 +146,13 @@ public class MemberController {
         memberService.insertPreferredRegions(regionDto, memberDetails.member());
         return CommonResponse.ok("success");
     }
+
+    /**
+     * 선호 시설 조회 컨트롤러
+     */
+    @GetMapping("/members/interests/places")
+    public ResponseEntity<?> getPreferredPlaces(@AuthenticationPrincipal MemberDetails memberDetails){
+        InterestDto dto = memberService.getPreferredPlaces(memberDetails.member());
+        return CommonResponse.ok("success", dto);
+    }
 }

--- a/backend/src/main/java/com/meong9/backend/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/meong9/backend/domain/member/controller/MemberController.java
@@ -116,4 +116,15 @@ public class MemberController {
         MyPageDetailDto dto = memberService.getMyPageDetail(memberDetails.member());
         return CommonResponse.ok("success", dto);
     }
+
+    /**
+     * 마이페이지 수정 컨트롤러
+     */
+    @PatchMapping("/members")
+    public ResponseEntity<?> updateMyPage(@RequestPart(name = "ProfileImage", required = false) MultipartFile profileImage,
+                                          @Valid @RequestPart(name = "UpdateMyPageRequestDto") MemberInfoDto requestDto,
+                                          @AuthenticationPrincipal MemberDetails memberDetails) throws IOException {
+        UpdateMyPageResponseDto dto = memberService.updateMyPage(profileImage, requestDto, memberDetails.member());
+        return CommonResponse.ok("success", dto);
+    }
 }

--- a/backend/src/main/java/com/meong9/backend/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/meong9/backend/domain/member/controller/MemberController.java
@@ -155,4 +155,14 @@ public class MemberController {
         InterestDto dto = memberService.getPreferredPlaces(memberDetails.member());
         return CommonResponse.ok("success", dto);
     }
+
+    /**
+     * 선호 시설 수정 컨트롤러
+     */
+    @PatchMapping("/members/interests/places")
+    public ResponseEntity<?> updatePreferredPlaces(@RequestBody InterestDto interestDto,
+                                                    @AuthenticationPrincipal MemberDetails memberDetails){
+        memberService.insertPreferredPlaces(interestDto, memberDetails.member());
+        return CommonResponse.ok("success");
+    }
 }

--- a/backend/src/main/java/com/meong9/backend/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/meong9/backend/domain/member/controller/MemberController.java
@@ -108,4 +108,12 @@ public class MemberController {
         return CommonResponse.ok("success", dto);
     }
 
+    /**
+     * 마이페이지 상세 조회 컨트롤러
+     */
+    @GetMapping("/members/detail")
+    public ResponseEntity<?> getMyPageDetail(@AuthenticationPrincipal MemberDetails memberDetails) {
+        MyPageDetailDto dto = memberService.getMyPageDetail(memberDetails.member());
+        return CommonResponse.ok("success", dto);
+    }
 }

--- a/backend/src/main/java/com/meong9/backend/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/meong9/backend/domain/member/controller/MemberController.java
@@ -131,9 +131,19 @@ public class MemberController {
     /**
      * 선호 지역 조회 컨트롤러
      */
-    @GetMapping("/members/interests/places")
+    @GetMapping("/members/interests/regions")
     public ResponseEntity<?> getPreferredRegions(@AuthenticationPrincipal MemberDetails memberDetails){
-        RegionDto dto = memberService.getPreferredRegions( memberDetails.member());
+        RegionDto dto = memberService.getPreferredRegions(memberDetails.member());
         return CommonResponse.ok("success", dto);
+    }
+
+    /**
+     * 선호 지역 수정 컨트롤러
+     */
+    @PatchMapping("/members/interests/regions")
+    public ResponseEntity<?> updatePreferredRegions(@RequestBody RegionDto regionDto,
+                                                 @AuthenticationPrincipal MemberDetails memberDetails){
+        memberService.insertPreferredRegions(regionDto, memberDetails.member());
+        return CommonResponse.ok("success");
     }
 }

--- a/backend/src/main/java/com/meong9/backend/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/meong9/backend/domain/member/controller/MemberController.java
@@ -1,9 +1,6 @@
 package com.meong9.backend.domain.member.controller;
 
-import com.meong9.backend.domain.member.dto.InterestDto;
-import com.meong9.backend.domain.member.dto.LoginResponseDto;
-import com.meong9.backend.domain.member.dto.MemberInfoDto;
-import com.meong9.backend.domain.member.dto.RegionDto;
+import com.meong9.backend.domain.member.dto.*;
 import com.meong9.backend.domain.member.service.KakaoService;
 import com.meong9.backend.domain.member.service.MemberService;
 import com.meong9.backend.global.auth.entity.MemberDetails;
@@ -101,4 +98,14 @@ public class MemberController {
         String message = isAvailable ? "사용 가능한 닉네임입니다." : "중복된 닉네임입니다.";
         return CommonResponse.ok(message);
     }
+
+    /**
+     * 마이페이지 조회 컨트롤러
+     */
+    @GetMapping("/members")
+    public ResponseEntity<?> getMyPage(@AuthenticationPrincipal MemberDetails memberDetails) {
+        MypageDto dto = memberService.getMyPage(memberDetails.member());
+        return CommonResponse.ok("success", dto);
+    }
+
 }

--- a/backend/src/main/java/com/meong9/backend/domain/member/dto/MyPageDetailDto.java
+++ b/backend/src/main/java/com/meong9/backend/domain/member/dto/MyPageDetailDto.java
@@ -1,0 +1,22 @@
+package com.meong9.backend.domain.member.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class MyPageDetailDto {
+    private final String email;
+    private final String name;
+    private final String nickname;
+    private final String phone;
+    private final String profileImageUrl;
+
+    @Builder
+    public MyPageDetailDto(String email, String name, String nickname, String phone, String profileImageUrl) {
+        this.email = email;
+        this.name = name;
+        this.nickname = nickname;
+        this.phone = phone;
+        this.profileImageUrl = profileImageUrl;
+    }
+}

--- a/backend/src/main/java/com/meong9/backend/domain/member/dto/MypageDto.java
+++ b/backend/src/main/java/com/meong9/backend/domain/member/dto/MypageDto.java
@@ -1,0 +1,22 @@
+package com.meong9.backend.domain.member.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class MypageDto {
+    private final Long memberId;
+    private final String nickname;
+    private final String profileImageUrl;
+    private final List<MypagePuppyDto> puppyList;
+
+    @Builder
+    public MypageDto(Long memberId, String nickname, String profileImageUrl, List<MypagePuppyDto> puppyList) {
+        this.memberId = memberId;
+        this.nickname = nickname;
+        this.profileImageUrl = profileImageUrl;
+        this.puppyList = puppyList;
+    }
+}

--- a/backend/src/main/java/com/meong9/backend/domain/member/dto/MypagePuppyDto.java
+++ b/backend/src/main/java/com/meong9/backend/domain/member/dto/MypagePuppyDto.java
@@ -1,0 +1,18 @@
+package com.meong9.backend.domain.member.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class MypagePuppyDto {
+    private final Long puppyId;
+    private final String puppyName;
+    private final String puppyImageUrl;
+
+    @Builder
+    public MypagePuppyDto(Long puppyId, String puppyName, String puppyImageUrl) {
+        this.puppyId = puppyId;
+        this.puppyName = puppyName;
+        this.puppyImageUrl = puppyImageUrl;
+    }
+}

--- a/backend/src/main/java/com/meong9/backend/domain/member/dto/UpdateMyPageResponseDto.java
+++ b/backend/src/main/java/com/meong9/backend/domain/member/dto/UpdateMyPageResponseDto.java
@@ -1,0 +1,20 @@
+package com.meong9.backend.domain.member.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class UpdateMyPageResponseDto {
+    private final String name;
+    private final String nickname;
+    private final String phone;
+    private final String profileImageUrl;
+
+    @Builder
+    public UpdateMyPageResponseDto(String name, String nickname, String phone, String profileImageUrl) {
+        this.name = name;
+        this.nickname = nickname;
+        this.phone = phone;
+        this.profileImageUrl = profileImageUrl;
+    }
+}

--- a/backend/src/main/java/com/meong9/backend/domain/member/entity/Member.java
+++ b/backend/src/main/java/com/meong9/backend/domain/member/entity/Member.java
@@ -1,9 +1,12 @@
 package com.meong9.backend.domain.member.entity;
 
+import com.meong9.backend.domain.puppy.entity.Puppy;
 import com.meong9.backend.global.entity.BaseTimeEntity;
 import com.meong9.backend.global.mediafile.entity.MediaFile;
 import jakarta.persistence.*;
 import lombok.*;
+
+import java.util.List;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -40,6 +43,9 @@ public class Member extends BaseTimeEntity {
     private MediaFile profileImage;
 
     private String roleCode = "010";
+
+    @OneToMany(mappedBy = "member", orphanRemoval = true)
+    private List<Puppy> puppies;
 
     @Builder
     public Member (String email, String name, String nickname, String provider, String providerId, MediaFile profileImage) {

--- a/backend/src/main/java/com/meong9/backend/domain/member/repository/FavoriteRegionRepository.java
+++ b/backend/src/main/java/com/meong9/backend/domain/member/repository/FavoriteRegionRepository.java
@@ -6,8 +6,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
+
 public interface FavoriteRegionRepository extends JpaRepository<FavoriteRegion, FavoriteRegionId>, FavoriteRegionJdbcRepository{
     @Modifying
     @Query("DELETE FROM FavoriteRegion fr WHERE fr.member.memberId = :memberId")
     void deleteByMemberId(Long memberId);
+
+    @Query("SELECT f FROM FavoriteRegion f where f.member.memberId = :memberId")
+    List<FavoriteRegion> findByMemberId(Long memberId);
 }

--- a/backend/src/main/java/com/meong9/backend/domain/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/meong9/backend/domain/member/repository/MemberRepository.java
@@ -2,6 +2,7 @@ package com.meong9.backend.domain.member.repository;
 
 import com.meong9.backend.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
@@ -11,4 +12,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByProviderId(String providerId);
 
     boolean existsByNickname(String nickname);
+
+    @Query("SELECT m FROM Member m JOIN FETCH m.profileImage WHERE m.memberId = :memberId")
+    Optional<Member> findMemberWithProfileImage(Long memberId);
 }

--- a/backend/src/main/java/com/meong9/backend/domain/member/repository/PlcFavCategoryRepository.java
+++ b/backend/src/main/java/com/meong9/backend/domain/member/repository/PlcFavCategoryRepository.java
@@ -7,9 +7,13 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
+
 public interface PlcFavCategoryRepository extends JpaRepository<PlcFavCategory, PlcFavCategoryId>, PlcFavCategoryJdbcRepository{
     @Modifying
     @Query("DELETE FROM PlcFavCategory p WHERE p.member.memberId = :memberId")
     void deleteByMemberId(@Param("memberId") Long memberId);
 
+    @Query("SELECT p FROM PlcFavCategory p where p.member.memberId = :memberId")
+    List<PlcFavCategory> findByMemberId(Long memberId);
 }

--- a/backend/src/main/java/com/meong9/backend/domain/member/service/MemberService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/member/service/MemberService.java
@@ -112,13 +112,7 @@ public class MemberService {
      * 사용자 정보를 등록하는 서비스 메서드
      */
     public void insertMemberInfo(MultipartFile profileImage,MemberInfoDto dto, Member member) throws IOException {
-        member.setName(dto.getName().trim());
-        member.setPhone(dto.getPhone().trim());
-        member.setNickname(dto.getNickname().trim());
-
-        if (profileImage != null) {
-            mediaFileService.uploadProfileImage(profileImage, member.getMemberId());
-        }
+        updateMember(profileImage, dto, member);
 
         memberRepository.save(member);
     }
@@ -167,5 +161,27 @@ public class MemberService {
                 .phone(foundMember.getPhone())
                 .profileImageUrl(foundMember.getProfileImage().getFileUrl())
                 .build();
+    }
+
+    public UpdateMyPageResponseDto updateMyPage(MultipartFile profileImage, MemberInfoDto dto, Member member) throws IOException {
+        updateMember(profileImage, dto, member);
+
+        Member savedMember = memberRepository.save(member);
+        return UpdateMyPageResponseDto.builder()
+                .name(savedMember.getName())
+                .phone(savedMember.getPhone())
+                .nickname(savedMember.getNickname())
+                .profileImageUrl(savedMember.getProfileImage().getFileUrl())
+                .build();
+    }
+
+    private void updateMember(MultipartFile profileImage, MemberInfoDto dto, Member member) throws IOException {
+        member.setName(dto.getName().trim());
+        member.setPhone(dto.getPhone().trim());
+        member.setNickname(dto.getNickname().trim());
+
+        if (profileImage != null) {
+            mediaFileService.uploadProfileImage(profileImage, member.getMemberId());
+        }
     }
 }

--- a/backend/src/main/java/com/meong9/backend/domain/member/service/MemberService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/member/service/MemberService.java
@@ -157,4 +157,15 @@ public class MemberService {
                 .puppyList(puppyList)
                 .build();
     }
+
+    public MyPageDetailDto getMyPageDetail(Member member) {
+        Member foundMember = memberRepository.findMemberWithProfileImage(member.getMemberId()).orElseThrow();
+        return MyPageDetailDto.builder()
+                .email(foundMember.getEmail())
+                .name(foundMember.getName())
+                .nickname(foundMember.getNickname())
+                .phone(foundMember.getPhone())
+                .profileImageUrl(foundMember.getProfileImage().getFileUrl())
+                .build();
+    }
 }

--- a/backend/src/main/java/com/meong9/backend/domain/member/service/MemberService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/member/service/MemberService.java
@@ -1,6 +1,7 @@
 package com.meong9.backend.domain.member.service;
 
 import com.meong9.backend.domain.member.dto.*;
+import com.meong9.backend.domain.member.entity.FavoriteRegion;
 import com.meong9.backend.domain.member.entity.Member;
 import com.meong9.backend.domain.member.repository.FavoriteRegionRepository;
 import com.meong9.backend.domain.member.repository.MemberRepository;
@@ -183,5 +184,12 @@ public class MemberService {
         if (profileImage != null) {
             mediaFileService.uploadProfileImage(profileImage, member.getMemberId());
         }
+    }
+
+    public RegionDto getPreferredRegions(Member member) {
+        List<FavoriteRegion> favRegionList = favoriteRegionRepository.findByMemberId(member.getMemberId());
+        return new RegionDto(favRegionList.stream()
+                .map(favoriteRegion -> favoriteRegion.getRegion().getName())
+                .collect(Collectors.toSet()));
     }
 }

--- a/backend/src/main/java/com/meong9/backend/domain/member/service/MemberService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/member/service/MemberService.java
@@ -1,14 +1,14 @@
 package com.meong9.backend.domain.member.service;
 
-import com.meong9.backend.domain.member.dto.InterestDto;
-import com.meong9.backend.domain.member.dto.MemberInfoDto;
-import com.meong9.backend.domain.member.dto.RegionDto;
+import com.meong9.backend.domain.member.dto.*;
 import com.meong9.backend.domain.member.entity.Member;
 import com.meong9.backend.domain.member.repository.FavoriteRegionRepository;
 import com.meong9.backend.domain.member.repository.MemberRepository;
 import com.meong9.backend.domain.member.repository.PlcFavCategoryRepository;
 import com.meong9.backend.domain.place.entity.PlcCategory;
 import com.meong9.backend.domain.place.repository.PlcCategoryRepository;
+import com.meong9.backend.domain.puppy.entity.Puppy;
+import com.meong9.backend.domain.puppy.repository.PuppyRepository;
 import com.meong9.backend.global.auth.refreshtoken.RefreshToken;
 import com.meong9.backend.global.auth.refreshtoken.RefreshTokenService;
 import com.meong9.backend.global.auth.utils.JwtProvider;
@@ -41,6 +41,7 @@ public class MemberService {
     private final FavoriteRegionRepository favoriteRegionRepository;
     private final RegionRepository regionRepository;
     private final MediaFileService mediaFileService;
+    private final PuppyRepository puppyRepository;
 
     /**
      * refresh token 사용하여 access token 재발급하는 서비스 메서드
@@ -122,11 +123,38 @@ public class MemberService {
         memberRepository.save(member);
     }
 
+    /**
+     * 프로필 이미지를 삭제하는 서비스 메서드
+     */
     public void deleteProfileImage(Member member) {
         mediaFileService.deleteProfileImage(member.getMemberId());
     }
 
+    /**
+     * 닉네임 중복을 확인하는 서비스 메서드
+     */
     public boolean isNicknameAvailable(String nickname) {
         return !memberRepository.existsByNickname(nickname);
+    }
+
+    /**
+     * 마이페이지를 조회하는 서비스 메서드
+     */
+    public MypageDto getMyPage(Member member) {
+        List<Puppy> puppies = puppyRepository.findByMemberIdWithPuppyProfileImage(member.getMemberId());
+        Member foundMember = memberRepository.findMemberWithProfileImage(member.getMemberId()).orElseThrow();
+        List<MypagePuppyDto> puppyList = puppies.stream()
+                .map(puppy -> MypagePuppyDto.builder()
+                        .puppyId(puppy.getPuppyId())
+                        .puppyName(puppy.getName())
+                        .puppyImageUrl(puppy.getProfileImage().getFileUrl())
+                        .build())
+                .toList();
+        return MypageDto.builder()
+                .memberId(foundMember.getMemberId())
+                .nickname(foundMember.getNickname())
+                .profileImageUrl(foundMember.getProfileImage().getFileUrl())
+                .puppyList(puppyList)
+                .build();
     }
 }

--- a/backend/src/main/java/com/meong9/backend/domain/member/service/MemberService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/member/service/MemberService.java
@@ -3,6 +3,7 @@ package com.meong9.backend.domain.member.service;
 import com.meong9.backend.domain.member.dto.*;
 import com.meong9.backend.domain.member.entity.FavoriteRegion;
 import com.meong9.backend.domain.member.entity.Member;
+import com.meong9.backend.domain.member.entity.PlcFavCategory;
 import com.meong9.backend.domain.member.repository.FavoriteRegionRepository;
 import com.meong9.backend.domain.member.repository.MemberRepository;
 import com.meong9.backend.domain.member.repository.PlcFavCategoryRepository;
@@ -190,6 +191,13 @@ public class MemberService {
         List<FavoriteRegion> favRegionList = favoriteRegionRepository.findByMemberId(member.getMemberId());
         return new RegionDto(favRegionList.stream()
                 .map(favoriteRegion -> favoriteRegion.getRegion().getName())
+                .collect(Collectors.toSet()));
+    }
+
+    public InterestDto getPreferredPlaces(Member member) {
+        List<PlcFavCategory> favCategoryList = plcFavCategoryRepository.findByMemberId(member.getMemberId());
+        return new InterestDto(favCategoryList.stream()
+                .map(favoritePlace -> favoritePlace.getPlcCategory().getName())
                 .collect(Collectors.toSet()));
     }
 }

--- a/backend/src/main/java/com/meong9/backend/domain/puppy/repository/PuppyRepository.java
+++ b/backend/src/main/java/com/meong9/backend/domain/puppy/repository/PuppyRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface PuppyRepository extends JpaRepository<Puppy, Long> {
@@ -26,4 +27,6 @@ public interface PuppyRepository extends JpaRepository<Puppy, Long> {
             "WHERE p.puppyId = :puppyId")
     Optional<PuppyProfileResponseDto> findPuppyProfileById(@Param("puppyId") Long puppyId);
 
+    @Query("SELECT p FROM Puppy p JOIN FETCH p.profileImage WHERE p.member.memberId = :memberId")
+    List<Puppy> findByMemberIdWithPuppyProfileImage(Long memberId);
 }


### PR DESCRIPTION
## 📋 Summary
<!-- 이 PR에서 변경된 주요 내용을 간략히 작성해주세요. -->
- 회원 정보 조회 및 수정 기능 추가
- Member에서 Puppies 조회할 수 있도록 양방향 연관관계 생성

## ✨ Feature Details
| Method | Path                      | Description      |
|--------|---------------------------|------------------|
| GET   | /api/v1/members | 마이페이지 조회        |
| GET   | /api/v1/members/detail | 마이페이지 상세 조회        |
| PATCH   | /api/v1/members | 회원 정보 수정       |
| GET   | /api/v1/members/interests/places | 회원 선호 시설 조회        |
| GET   | /api/v1/members/interests/regions | 회원 선호 지역 조회        |
| PATCH   | /api/v1/members/interests/places | 회원 선호 시설 수정        |
| PATCH   | /api/v1/members/interests/regions | 회원 선호 지역 수정       |

## 💡 Key Considerations
<!-- 구현하면서 고려한 점, 또는 해결한 주요 이슈를 간단히 작성해주세요. -->
1. 회원 선호 시설과 지역 수정 시, 기존 insertPreferredPlaces/Regions 서비스 메서드 활용
- 선호 시설과 지역을 처음 생성할 때, 복합키가 걸려 있어 JPA에서 select 문이 각각 날아가는 부분을 줄이기 위해 한번 delete로 삭제한 후 batch insert 하도록 jdbc 쿼리를 사용함. 기존 jpa 메서드 활용했을 때보다 3개의 쿼리로 해결이 가능함. 
- 수정 또한 이 메서드를 활용하기가 적절하기에 사용. 

2. Member-Puppy 양방향 연관관계
- 회원의 강아지들을 조회할 때, 회원쪽에서 조회를 할 수 없어 양방향 연관관계로 수정함. 이전은 강아지에서 회원을 조회 가능한 단방향이었음. 

3. findMemberWithProfileImage / findPuppyWithProfileImage
- 프로필 이미지가 lazy loading이 걸려 있어 fetch join 쿼리 추가함.
- member에서 프로필 이미지를 사용하는 경우가 많아, eager로 변경하거나 시큐리티에서 아예 프로필 이미지를 찾아오는 쪽이 나을 듯한데... 쿼리 최적화하면서 한꺼번에 살펴보려 함. 

## ✅ Checklist
- [X] 코드를 스스로 검토했나요?
- [X] 필요한 테스트를 추가하고 모두 통과했나요? (포스트맨 확인)
- [X] 브랜치 전략에 맞는 브랜치에 PR을 올렸나요?
- [X] 커밋 메시지가 컨벤션에 맞나요?
- [X] 필요한 문서를 업데이트했나요? 
