### PR TITLE
From KAN-47-BE-feat/favorites into dev

### DIFF
--- a/backend/src/main/java/com/meong9/backend/domain/like/controller/LikeController.java
+++ b/backend/src/main/java/com/meong9/backend/domain/like/controller/LikeController.java
@@ -5,6 +5,7 @@ import com.meong9.backend.domain.member.entity.Member;
 import com.meong9.backend.domain.member.service.MemberService;
 import com.meong9.backend.domain.pension.entity.Pension;
 import com.meong9.backend.domain.place.entity.Place;
+import com.meong9.backend.global.annotation.member.CurrentMember;
 import com.meong9.backend.global.auth.entity.MemberDetails;
 import com.meong9.backend.global.dto.CommonResponse;
 import lombok.RequiredArgsConstructor;
@@ -25,14 +26,12 @@ public class LikeController {
     private final MemberService memberService;
 
     @PostMapping("/places/likes/{placeId}")
-    public ResponseEntity<?> togglePlaceLike(@AuthenticationPrincipal MemberDetails memberDetails,@PathVariable Long placeId) {
-        Member member=memberDetails.member();
+    public ResponseEntity<?> togglePlaceLike(@CurrentMember Member member,@PathVariable Long placeId) {
         return CommonResponse.created(likeService.togglePlaceLike(member, placeId));
     }
 
     @PostMapping("/pensions/likes/{pensionId}")
-    public ResponseEntity<?> togglePensionLike(@AuthenticationPrincipal MemberDetails memberDetails, @PathVariable Long pensionId) {
-        Member member=memberDetails.member();
+    public ResponseEntity<?> togglePensionLike(@CurrentMember Member member, @PathVariable Long pensionId) {
         return CommonResponse.created(likeService.togglePensionLike(member, pensionId));
     }
 

--- a/backend/src/main/java/com/meong9/backend/domain/like/controller/LikeController.java
+++ b/backend/src/main/java/com/meong9/backend/domain/like/controller/LikeController.java
@@ -14,6 +14,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -23,7 +24,6 @@ import java.util.concurrent.ConcurrentHashMap;
 @Slf4j
 public class LikeController {
     private final LikeService likeService;
-    private final MemberService memberService;
 
     @PostMapping("/places/likes/{placeId}")
     public ResponseEntity<?> togglePlaceLike(@CurrentMember Member member,@PathVariable Long placeId) {
@@ -35,4 +35,16 @@ public class LikeController {
         return CommonResponse.created(likeService.togglePensionLike(member, pensionId));
     }
 
+    // Place 즐겨찾기 상태 조회
+    @GetMapping("/places/likes/{placeId}")
+    public ResponseEntity<?> getPlaceLikeStatus(@PathVariable Long placeId, @CurrentMember Member member) {
+        return CommonResponse.ok(likeService.isPlaceLikedByMember(member, placeId) ? "찜한 시설입니다." : "찜하지 않은 시설입니다.");
+
+    }
+
+    // Pension 즐겨찾기 상태 조회
+    @GetMapping("/pensions/likes/{pensionId}")
+    public ResponseEntity<?> getPensionLikeStatus(@PathVariable Long pensionId, @CurrentMember Member member) {
+        return CommonResponse.ok(likeService.isPensionLikedByMember(member, pensionId) ? "찜한 펜션입니다." : "찜하지 않은 펜션입니다.");
+    }
 }

--- a/backend/src/main/java/com/meong9/backend/domain/like/entity/Like.java
+++ b/backend/src/main/java/com/meong9/backend/domain/like/entity/Like.java
@@ -18,6 +18,12 @@ import lombok.NoArgsConstructor;
         uniqueConstraints = {
                 @UniqueConstraint(columnNames = {"member_id", "pension_id"}),
                 @UniqueConstraint(columnNames = {"member_id", "place_id"})
+        },
+        indexes = {
+                @Index(name = "idx_member_pension", columnList = "member_id, pension_id"),
+                @Index(name = "idx_member_place", columnList = "member_id, place_id"),
+//                @Index(name = "idx_pension_id", columnList = "pension_id"),
+//                @Index(name = "idx_place_id", columnList = "place_id")
         }
 )
 public class Like {

--- a/backend/src/main/java/com/meong9/backend/domain/like/repository/LikeRepository.java
+++ b/backend/src/main/java/com/meong9/backend/domain/like/repository/LikeRepository.java
@@ -7,6 +7,8 @@ import com.meong9.backend.domain.member.entity.Member;
 import com.meong9.backend.domain.pension.entity.Pension;
 import com.meong9.backend.domain.place.entity.Place;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -15,4 +17,12 @@ import java.util.Optional;
 public interface LikeRepository extends JpaRepository<Like, Long> {
     Optional<PlaceLike> findByMemberAndPlace(Member member, Place place);
     Optional<PensionLike> findByMemberAndPension(Member member, Pension pension);
+
+    // Place 즐겨찾기 상태 확인
+    @Query("SELECT COUNT(*) > 0 FROM PlaceLike pl WHERE pl.member = :member AND pl.place.placeId = :placeId")
+    boolean existsByMemberAndPlaceId(@Param("member") Member member, @Param("placeId") Long placeId);
+
+    // Pension 즐겨찾기 상태 확인
+    @Query("SELECT COUNT(*) > 0 FROM PensionLike pl WHERE pl.member = :member AND pl.pension.pensionId = :pensionId")
+    boolean existsByMemberAndPensionId(@Param("member") Member member, @Param("pensionId") Long pensionId);
 }

--- a/backend/src/main/java/com/meong9/backend/domain/like/repository/LikeRepository.java
+++ b/backend/src/main/java/com/meong9/backend/domain/like/repository/LikeRepository.java
@@ -19,10 +19,26 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
     Optional<PensionLike> findByMemberAndPension(Member member, Pension pension);
 
     // Place 즐겨찾기 상태 확인
-    @Query("SELECT COUNT(*) > 0 FROM PlaceLike pl WHERE pl.member = :member AND pl.place.placeId = :placeId")
+    @Query("""
+            SELECT CASE 
+                WHEN COUNT(pl) > 0 
+                THEN true 
+                ELSE false 
+                END
+            FROM PlaceLike pl
+            WHERE pl.member = :member AND pl.place.placeId = :placeId
+            """)
     boolean existsByMemberAndPlaceId(@Param("member") Member member, @Param("placeId") Long placeId);
 
     // Pension 즐겨찾기 상태 확인
-    @Query("SELECT COUNT(*) > 0 FROM PensionLike pl WHERE pl.member = :member AND pl.pension.pensionId = :pensionId")
+    @Query("""
+            SELECT CASE 
+                WHEN COUNT(pl) > 0 
+                THEN true 
+                ELSE false 
+                END
+            FROM PensionLike pl
+            WHERE pl.member = :member AND pl.pension.pensionId = :pensionId
+            """)
     boolean existsByMemberAndPensionId(@Param("member") Member member, @Param("pensionId") Long pensionId);
 }

--- a/backend/src/main/java/com/meong9/backend/domain/like/service/LikeService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/like/service/LikeService.java
@@ -12,8 +12,6 @@ import com.meong9.backend.global.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
 
 @Service
 @RequiredArgsConstructor
@@ -42,7 +40,7 @@ public class LikeService {
 
     @Transactional
     public String togglePensionLike(Member member, Long pensionId) {
-        Pension pension=pensionRepository.findById(pensionId).orElseThrow(()->NotFoundException.entityNotFound("장소"));
+        Pension pension=pensionRepository.findById(pensionId).orElseThrow(()->NotFoundException.entityNotFound("펜션"));
         return likeRepository.findByMemberAndPension(member, pension)
                 .map(like -> {
                     pension.decreaseLikeCount();
@@ -54,5 +52,17 @@ public class LikeService {
                     likeRepository.save(new PensionLike(member, pension));
                     return "찜하기가 등록되었습니다.";
                 });
+    }
+
+    // Place 즐겨찾기 여부 확인
+    @Transactional(readOnly = true)
+    public boolean isPlaceLikedByMember(Member member, Long placeId) {
+        return likeRepository.existsByMemberAndPlaceId(member, placeId);
+    }
+
+    // Pension 즐겨찾기 여부 확인
+    @Transactional(readOnly = true)
+    public boolean isPensionLikedByMember(Member member, Long pensionId) {
+        return likeRepository.existsByMemberAndPensionId(member, pensionId);
     }
 }

--- a/backend/src/main/java/com/meong9/backend/domain/like/service/LikeService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/like/service/LikeService.java
@@ -25,13 +25,16 @@ public class LikeService {
     @Transactional
     public String togglePlaceLike(Member member, Long placeId) {
         Place place=placeRepository.findById(placeId).orElseThrow(()->NotFoundException.entityNotFound("장소"));
+
         place.increaseLikeCount();
         return likeRepository.findByMemberAndPlace(member, place)
                 .map(like -> {
+                    place.decreaseLikeCount();
                     likeRepository.delete(like);
                     return "찜하기가 취소되었습니다.";
                 })
                 .orElseGet(() -> {
+                    place.increaseLikeCount();
                     likeRepository.save(new PlaceLike(member, place));
                     return "찜하기가 등록되었습니다.";
                 });
@@ -40,13 +43,14 @@ public class LikeService {
     @Transactional
     public String togglePensionLike(Member member, Long pensionId) {
         Pension pension=pensionRepository.findById(pensionId).orElseThrow(()->NotFoundException.entityNotFound("장소"));
-        pension.increaseLikeCount();
         return likeRepository.findByMemberAndPension(member, pension)
                 .map(like -> {
+                    pension.decreaseLikeCount();
                     likeRepository.delete(like);
                     return "찜하기가 취소되었습니다.";
                 })
                 .orElseGet(() -> {
+                    pension.increaseLikeCount();
                     likeRepository.save(new PensionLike(member, pension));
                     return "찜하기가 등록되었습니다.";
                 });

--- a/backend/src/main/java/com/meong9/backend/domain/pension/entity/Pension.java
+++ b/backend/src/main/java/com/meong9/backend/domain/pension/entity/Pension.java
@@ -53,4 +53,8 @@ public class Pension {
     public void increaseLikeCount(){
         this.likeCount++;
     }
+
+    public void decreaseLikeCount(){
+        this.likeCount=Math.max(this.likeCount-1,0);
+    }
 }

--- a/backend/src/main/java/com/meong9/backend/domain/place/entity/Place.java
+++ b/backend/src/main/java/com/meong9/backend/domain/place/entity/Place.java
@@ -57,4 +57,8 @@ public class Place {
     public void increaseLikeCount(){
         this.likeCount++;
     }
+
+    public void decreaseLikeCount(){
+        this.likeCount=Math.max(this.likeCount-1,0);
+    }
 }

--- a/backend/src/main/java/com/meong9/backend/global/annotation/member/CurrentMember.java
+++ b/backend/src/main/java/com/meong9/backend/global/annotation/member/CurrentMember.java
@@ -1,0 +1,9 @@
+package com.meong9.backend.global.annotation.member;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface CurrentMember {
+}

--- a/backend/src/main/java/com/meong9/backend/global/annotation/member/CurrentMemberArgumentResolver.java
+++ b/backend/src/main/java/com/meong9/backend/global/annotation/member/CurrentMemberArgumentResolver.java
@@ -1,0 +1,32 @@
+package com.meong9.backend.global.annotation.member;
+
+import com.meong9.backend.domain.member.entity.Member;
+import com.meong9.backend.global.auth.entity.MemberDetails;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class CurrentMemberArgumentResolver implements HandlerMethodArgumentResolver {
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(CurrentMember.class) &&
+                parameter.getParameterType().equals(Member.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter,
+                                  ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest,
+                                  WebDataBinderFactory binderFactory) throws Exception {
+        MemberDetails memberDetails = (MemberDetails) SecurityContextHolder
+                .getContext()
+                .getAuthentication()
+                .getPrincipal();
+        return memberDetails.member(); // Member 객체를 반환
+    }
+}

--- a/backend/src/main/java/com/meong9/backend/global/annotation/member/CurrentMemberArgumentResolver.java
+++ b/backend/src/main/java/com/meong9/backend/global/annotation/member/CurrentMemberArgumentResolver.java
@@ -2,6 +2,7 @@ package com.meong9.backend.global.annotation.member;
 
 import com.meong9.backend.domain.member.entity.Member;
 import com.meong9.backend.global.auth.entity.MemberDetails;
+import jakarta.validation.constraints.NotNull;
 import org.springframework.core.MethodParameter;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;

--- a/backend/src/main/java/com/meong9/backend/global/config/WebConfig.java
+++ b/backend/src/main/java/com/meong9/backend/global/config/WebConfig.java
@@ -1,0 +1,22 @@
+package com.meong9.backend.global.config;
+
+import com.meong9.backend.global.annotation.member.CurrentMemberArgumentResolver;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    private final CurrentMemberArgumentResolver currentMemberArgumentResolver;
+
+    public WebConfig(CurrentMemberArgumentResolver currentMemberArgumentResolver) {
+        this.currentMemberArgumentResolver = currentMemberArgumentResolver;
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(currentMemberArgumentResolver);
+    }
+}


### PR DESCRIPTION
## 📋 Summary
- **★매우 중요★** `@CurrentMember` 어노테이션 생성
- 시설을 즐겨찾기했는지 여부 조회

## ✨ Feature Details
| Method | Path                      | Description      |
|--------|---------------------------|------------------|
| GET | /api/v1/places/likes/{placeId} | 장소 즐겨찾기 상태 조회    |
| GET  | /api/v1/pensions/likes/{pensionId}| 펜션 즐겨찾기 상태 조회        |

## 💡 Key Considerations
- 컨트롤러에서 매번 `@AuthenticationPrincipal`를 파라미터로 받아 Member 생성 메서드를 호출하는 것이 번거로워 **@CurrentMember Member member**를 파라미터로 받아 바로 Member를 가져오도록 했음(이것조차도 더 간소화할 수 있을지도...?)
- 인덱스를 {member_id, pension_id}, {member_id, place_id} 두 쌍으로 걸었음
- 즐겨찾기 했는지 여부를 판단할 때, 조회 시 1개만 발견하는 즉시 true를 반환하도록 하여 성능 개선
- 참고: https://jojoldu.tistory.com/516

## ✅ Checklist
- [x] 코드를 스스로 검토했나요?
- [x] 필요한 테스트를 추가하고 모두 통과했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올렸나요?
- [x] 커밋 메시지가 컨벤션에 맞나요?
- [ ] 필요한 문서를 업데이트했나요?
