### PR TITLE
From KAN-73-BE-feat/refreshToken into dev

### DIFF
--- a/backend/src/main/java/com/meong9/backend/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/meong9/backend/domain/member/controller/MemberController.java
@@ -40,10 +40,12 @@ public class MemberController {
      * access token 재발급 요청 처리 컨트롤러
      */
     @PostMapping("/auth/token")
-    public ResponseEntity<?> refreshAccessToken(@RequestHeader("Refresh-Token") String refreshToken) {
+    public ResponseEntity<?> refreshAccessToken(@CookieValue(name = "Refresh-token") String refreshToken) {
         String newAccessToken = memberService.refreshAccessToken(refreshToken);
+
         HttpHeaders headers = new HttpHeaders();
         headers.set(JwtProvider.AUTHORIZATION_HEADER, newAccessToken);
+
         return ResponseEntity.ok()
                 .headers(headers)
                 .body(Map.of("message", "Access Token이 재발급되었습니다."));

--- a/backend/src/main/java/com/meong9/backend/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/meong9/backend/domain/member/controller/MemberController.java
@@ -5,7 +5,6 @@ import com.meong9.backend.domain.member.entity.Member;
 import com.meong9.backend.domain.member.service.KakaoService;
 import com.meong9.backend.domain.member.service.MemberService;
 import com.meong9.backend.global.annotation.member.CurrentMember;
-import com.meong9.backend.global.auth.entity.MemberDetails;
 import com.meong9.backend.global.auth.utils.JwtProvider;
 import com.meong9.backend.global.dto.CommonResponse;
 import jakarta.servlet.http.HttpServletResponse;
@@ -14,7 +13,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 

--- a/backend/src/main/java/com/meong9/backend/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/meong9/backend/domain/member/controller/MemberController.java
@@ -1,8 +1,10 @@
 package com.meong9.backend.domain.member.controller;
 
 import com.meong9.backend.domain.member.dto.*;
+import com.meong9.backend.domain.member.entity.Member;
 import com.meong9.backend.domain.member.service.KakaoService;
 import com.meong9.backend.domain.member.service.MemberService;
+import com.meong9.backend.global.annotation.member.CurrentMember;
 import com.meong9.backend.global.auth.entity.MemberDetails;
 import com.meong9.backend.global.auth.utils.JwtProvider;
 import com.meong9.backend.global.dto.CommonResponse;
@@ -56,8 +58,8 @@ public class MemberController {
      */
     @PostMapping("/members/interests/places")
     public ResponseEntity<?> insertPreferredPlaces(@RequestBody InterestDto dto,
-                                                   @AuthenticationPrincipal MemberDetails memberDetails) {
-        memberService.insertPreferredPlaces(dto, memberDetails.member());
+                                                   @CurrentMember Member member) {
+        memberService.insertPreferredPlaces(dto, member);
         return CommonResponse.ok("success");
     }
 
@@ -66,8 +68,8 @@ public class MemberController {
      */
     @PostMapping("/members/interests/regions")
     public ResponseEntity<?> insertPreferredRegions(@RequestBody RegionDto dto,
-                                                    @AuthenticationPrincipal MemberDetails memberDetails) {
-        memberService.insertPreferredRegions(dto, memberDetails.member());
+                                                    @CurrentMember Member member) {
+        memberService.insertPreferredRegions(dto, member);
         return CommonResponse.ok("success");
     }
 
@@ -77,8 +79,8 @@ public class MemberController {
     @PostMapping("/members/info")
     public ResponseEntity<?> insertMemberInfo(@RequestPart(name = "ProfileImage", required = false) MultipartFile profileImage,
                                               @Valid @RequestPart(name = "MemberInfoDto") MemberInfoDto dto,
-                                              @AuthenticationPrincipal MemberDetails memberDetails) throws IOException {
-        memberService.insertMemberInfo(profileImage, dto, memberDetails.member());
+                                              @CurrentMember Member member) throws IOException {
+        memberService.insertMemberInfo(profileImage, dto, member);
         return CommonResponse.ok("success");
     }
 
@@ -86,8 +88,8 @@ public class MemberController {
      * 프로필 사진 삭제 요청 컨트롤러
      */
     @DeleteMapping("/members/images")
-    public ResponseEntity<?> deleteProfileImage(@AuthenticationPrincipal MemberDetails memberDetails) {
-        memberService.deleteProfileImage(memberDetails.member());
+    public ResponseEntity<?> deleteProfileImage(@CurrentMember Member member) {
+        memberService.deleteProfileImage(member);
         return CommonResponse.ok("success");
     }
 
@@ -105,8 +107,8 @@ public class MemberController {
      * 마이페이지 조회 컨트롤러
      */
     @GetMapping("/members")
-    public ResponseEntity<?> getMyPage(@AuthenticationPrincipal MemberDetails memberDetails) {
-        MypageDto dto = memberService.getMyPage(memberDetails.member());
+    public ResponseEntity<?> getMyPage(@CurrentMember Member member) {
+        MypageDto dto = memberService.getMyPage(member);
         return CommonResponse.ok("success", dto);
     }
 
@@ -114,8 +116,8 @@ public class MemberController {
      * 마이페이지 상세 조회 컨트롤러
      */
     @GetMapping("/members/detail")
-    public ResponseEntity<?> getMyPageDetail(@AuthenticationPrincipal MemberDetails memberDetails) {
-        MyPageDetailDto dto = memberService.getMyPageDetail(memberDetails.member());
+    public ResponseEntity<?> getMyPageDetail(@CurrentMember Member member) {
+        MyPageDetailDto dto = memberService.getMyPageDetail(member);
         return CommonResponse.ok("success", dto);
     }
 
@@ -125,8 +127,8 @@ public class MemberController {
     @PatchMapping("/members")
     public ResponseEntity<?> updateMyPage(@RequestPart(name = "ProfileImage", required = false) MultipartFile profileImage,
                                           @Valid @RequestPart(name = "UpdateMyPageRequestDto") MemberInfoDto requestDto,
-                                          @AuthenticationPrincipal MemberDetails memberDetails) throws IOException {
-        UpdateMyPageResponseDto dto = memberService.updateMyPage(profileImage, requestDto, memberDetails.member());
+                                          @CurrentMember Member member) throws IOException {
+        UpdateMyPageResponseDto dto = memberService.updateMyPage(profileImage, requestDto, member);
         return CommonResponse.ok("success", dto);
     }
 
@@ -134,8 +136,8 @@ public class MemberController {
      * 선호 지역 조회 컨트롤러
      */
     @GetMapping("/members/interests/regions")
-    public ResponseEntity<?> getPreferredRegions(@AuthenticationPrincipal MemberDetails memberDetails){
-        RegionDto dto = memberService.getPreferredRegions(memberDetails.member());
+    public ResponseEntity<?> getPreferredRegions(@CurrentMember Member member){
+        RegionDto dto = memberService.getPreferredRegions(member);
         return CommonResponse.ok("success", dto);
     }
 
@@ -144,8 +146,8 @@ public class MemberController {
      */
     @PatchMapping("/members/interests/regions")
     public ResponseEntity<?> updatePreferredRegions(@RequestBody RegionDto regionDto,
-                                                 @AuthenticationPrincipal MemberDetails memberDetails){
-        memberService.insertPreferredRegions(regionDto, memberDetails.member());
+                                                    @CurrentMember Member member){
+        memberService.insertPreferredRegions(regionDto, member);
         return CommonResponse.ok("success");
     }
 
@@ -153,8 +155,8 @@ public class MemberController {
      * 선호 시설 조회 컨트롤러
      */
     @GetMapping("/members/interests/places")
-    public ResponseEntity<?> getPreferredPlaces(@AuthenticationPrincipal MemberDetails memberDetails){
-        InterestDto dto = memberService.getPreferredPlaces(memberDetails.member());
+    public ResponseEntity<?> getPreferredPlaces(@CurrentMember Member member){
+        InterestDto dto = memberService.getPreferredPlaces(member);
         return CommonResponse.ok("success", dto);
     }
 
@@ -163,8 +165,8 @@ public class MemberController {
      */
     @PatchMapping("/members/interests/places")
     public ResponseEntity<?> updatePreferredPlaces(@RequestBody InterestDto interestDto,
-                                                    @AuthenticationPrincipal MemberDetails memberDetails){
-        memberService.insertPreferredPlaces(interestDto, memberDetails.member());
+                                                   @CurrentMember Member member){
+        memberService.insertPreferredPlaces(interestDto, member);
         return CommonResponse.ok("success");
     }
 }

--- a/backend/src/main/java/com/meong9/backend/domain/member/service/KakaoService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/member/service/KakaoService.java
@@ -19,6 +19,7 @@ import com.meong9.backend.global.exception.AuthenticationException;
 import com.meong9.backend.global.exception.ConflictException;
 import com.meong9.backend.global.mediafile.repository.MediaFileRepository;
 import com.meong9.backend.global.mediafile.service.MediaFileService;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -84,7 +85,7 @@ public class KakaoService {
         response.addHeader(JwtProvider.AUTHORIZATION_HEADER, accessToken);
 
         String refreshToken = jwtProvider.createRefreshToken(kakaoUser.getEmail(), kakaoUser.getRoleCode());
-        response.addHeader(JwtProvider.REFRESH_TOKEN_HEADER, refreshToken);
+        jwtProvider.addJwtToCookie(refreshToken, response);
 
         refreshTokenService.insertRefreshToken(kakaoUser.getEmail(), refreshToken.substring(7));
 

--- a/backend/src/main/java/com/meong9/backend/global/auth/utils/JwtProvider.java
+++ b/backend/src/main/java/com/meong9/backend/global/auth/utils/JwtProvider.java
@@ -6,12 +6,17 @@ import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.util.Date;
 
@@ -106,5 +111,19 @@ public class JwtProvider {
                 .build()
                 .parseClaimsJws(token)
                 .getBody();
+    }
+
+    public void addJwtToCookie(String token, HttpServletResponse res) {
+        token = URLEncoder.encode(token, StandardCharsets.UTF_8).replaceAll("\\+", "%20");
+        Cookie cookie = new Cookie(JwtProvider.REFRESH_TOKEN_HEADER, token);
+
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setAttribute("SameSite", "None");
+
+        int maxAgeInSeconds = 3600; // 1시간
+        cookie.setMaxAge(7 * 24 * maxAgeInSeconds);
+        res.addCookie(cookie);
     }
 }


### PR DESCRIPTION
## 📋 Summary
<!-- 이 PR에서 변경된 주요 내용을 간략히 작성해주세요. -->
- 헤더로 전달하던 Refresh Token을 쿠키로 전달하도록 변경

## ✨ Feature Details
| Method | Path                      | Description      |
|--------|---------------------------|------------------|


## 💡 Key Considerations
<!-- 구현하면서 고려한 점, 또는 해결한 주요 이슈를 간단히 작성해주세요. -->
1. rt 헤더에서 쿠키로 전달
- 유효시간이 긴 rt를 xss 공격을 받기 쉬운 로컬 스토리지에 저장하지 않도록 쿠키로 전달한다. 
2. CurrentMember 어노테이션 사용하도록 리팩토링

## ✅ Checklist
- [X] 코드를 스스로 검토했나요?
- [X] 필요한 테스트를 추가하고 모두 통과했나요?
- [X] 브랜치 전략에 맞는 브랜치에 PR을 올렸나요?
- [X] 커밋 메시지가 컨벤션에 맞나요?
- [X] 필요한 문서를 업데이트했나요?
