### PR TITLE
From KAN-48-BE-feat/search into dev : 장소 검색 생성

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -74,16 +74,16 @@ jooq {
 		main { // "main"이라는 기본 설정
 			generationTool {
 				jdbc {
-					driver = 'com.mysql.cj.jdbc.Driver' // Database driver
-					url = 'jdbc:mysql://localhost:3306/meong9' // Database URL
-					user = 'root' // Database username
-					password = 'root' // Database password
+					driver = 'com.mysql.cj.jdbc.Driver'
+					url = 'jdbc:mysql://localhost:3306/meong9'
+					user = 'root'
+					password = 'root'
 				}
 				generator {
 					database {
-						name = 'org.jooq.meta.mysql.MySQLDatabase' // MySQL 사용
-						inputSchema = 'meong9' // 대상 스키마
-						includes = '.*' // 모든 테이블 포함
+						name = 'org.jooq.meta.mysql.MySQLDatabase'
+						inputSchema = 'meong9'
+						includes = '.*'
 					}
 					target {
 						packageName = 'com.meong9.backend.jooq.generated' // 생성된 코드를 저장할 패키지

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.3.5'
 	id 'io.spring.dependency-management' version '1.1.6'
+	id 'nu.studer.jooq' version '8.2' // Jooq Gradle 플러그인 추가
 }
 
 group = 'com.meong9'
@@ -24,6 +25,13 @@ repositories {
 }
 
 dependencies {
+	// Jooq
+	implementation 'org.jooq:jooq:3.18.0'
+	implementation 'org.jooq:jooq-meta:3.18.0'
+	implementation 'org.jooq:jooq-codegen:3.18.0'
+	jooqGenerator 'mysql:mysql-connector-java:8.0.33'
+	implementation 'org.springframework.boot:spring-boot-starter-jooq'
+
 	// Validation
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
@@ -62,4 +70,39 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+jooq {
+	version = '3.18.0' // Jooq 버전
+	configurations {
+		main { // "main"이라는 기본 설정
+			generationTool {
+				jdbc {
+					driver = 'com.mysql.cj.jdbc.Driver' // Database driver
+					url = 'jdbc:mysql://localhost:3306/meong9' // Database URL
+					user = 'root' // Database username
+					password = 'root' // Database password
+				}
+				generator {
+					database {
+						name = 'org.jooq.meta.mysql.MySQLDatabase' // MySQL 사용
+						inputSchema = 'meong9' // 대상 스키마
+						includes = '.*' // 모든 테이블 포함
+					}
+					target {
+						packageName = 'com.meong9.backend.jooq.generated' // 생성된 코드를 저장할 패키지
+						directory = "$buildDir/generated/jooq" // 생성된 코드 저장 위치
+					}
+				}
+			}
+		}
+	}
+}
+
+sourceSets {
+	main {
+		java {
+			srcDirs "$buildDir/generated/jooq" // 생성된 Jooq 코드를 소스 경로에 추가
+		}
+	}
 }

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -48,16 +48,12 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 
-	// https://mvnrepository.com/artifact/org.apache.mahout/mahout-core
-	// https://mvnrepository.com/artifact/org.apache.mahout/mahout-mr
+	// Mahout & Mahout Integration (JDBC Support)
 	implementation group: 'org.apache.mahout', name: 'mahout-mr', version: '0.13.0'
-
-	// https://mvnrepository.com/artifact/org.apache.mahout/mahout-math
 	implementation group: 'org.apache.mahout', name: 'mahout-math', version: '0.13.0'
-
-	// Mahout Integration (JDBC Support)
 	implementation 'org.apache.mahout:mahout-integration:0.13.0'
 
+	// Batch
 	implementation 'org.springframework.boot:spring-boot-starter-batch'
 	implementation 'org.springframework.batch:spring-batch-core:5.1.0'
 

--- a/backend/src/main/java/com/meong9/backend/domain/address/entity/Address.java
+++ b/backend/src/main/java/com/meong9/backend/domain/address/entity/Address.java
@@ -32,7 +32,7 @@ public class Address {
     @Column(name = "zip_no", length = 5)
     private String zipNo;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "region_id")
     private Region region;
 }

--- a/backend/src/main/java/com/meong9/backend/domain/address/repository/AddressRepository.java
+++ b/backend/src/main/java/com/meong9/backend/domain/address/repository/AddressRepository.java
@@ -1,0 +1,7 @@
+package com.meong9.backend.domain.address.repository;
+
+import com.meong9.backend.domain.address.entity.Address;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AddressRepository extends JpaRepository<Address, Long> {
+}

--- a/backend/src/main/java/com/meong9/backend/domain/address/repository/PlcPenAddressRepository.java
+++ b/backend/src/main/java/com/meong9/backend/domain/address/repository/PlcPenAddressRepository.java
@@ -5,7 +5,25 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface PlcPenAddressRepository extends JpaRepository<PlcPenAddress, Long> {
     @Query("select ppa from PlcPenAddress ppa where ppa.plcPenId =:plcPenId and ppa.type =:type")
-    PlcPenAddress findByPlcPenIdAndType(@Param("plcPenId")Long plcPenId, @Param("type")String type);
+    Optional<PlcPenAddress> findByPlcPenIdAndType(@Param("plcPenId")Long plcPenId, @Param("type")String type);
+
+    @Query("""
+            SELECT ppa.plcPenId FROM PlcPenAddress ppa
+            WHERE ppa.address.region.regionId IN :regionIds
+            AND ppa.type = :typeCode
+            """)
+    List<Long> findPlaceIdsByRegionIdIn(@Param("regionIds") List<Long> regionIds, @Param("typeCode") String typeCode);
+
+    @Query("""
+            SELECT ppa.plcPenId, ppa.address.address
+            FROM PlcPenAddress ppa
+            WHERE ppa.plcPenId IN :placeIds AND ppa.type = :typeCode
+            """)
+    List<Object[]> findAddressesByPlaceIdsAndType(@Param("placeIds") List<Long> placeIds, @Param("typeCode") String typeCode);
+
 }

--- a/backend/src/main/java/com/meong9/backend/domain/address/repository/PlcPenAddressRepository.java
+++ b/backend/src/main/java/com/meong9/backend/domain/address/repository/PlcPenAddressRepository.java
@@ -17,13 +17,6 @@ public interface PlcPenAddressRepository extends JpaRepository<PlcPenAddress, Lo
             WHERE ppa.address.region.regionId IN :regionIds
             AND ppa.type = :typeCode
             """)
-    List<Long> findPlaceIdsByRegionIdIn(@Param("regionIds") List<Long> regionIds, @Param("typeCode") String typeCode);
-
-    @Query("""
-            SELECT ppa.plcPenId, ppa.address.address
-            FROM PlcPenAddress ppa
-            WHERE ppa.plcPenId IN :placeIds AND ppa.type = :typeCode
-            """)
-    List<Object[]> findAddressesByPlaceIdsAndType(@Param("placeIds") List<Long> placeIds, @Param("typeCode") String typeCode);
+    List<Long> findFacilityIdsByRegionIdIn(@Param("regionIds") List<Long> regionIds, @Param("typeCode") String typeCode);
 
 }

--- a/backend/src/main/java/com/meong9/backend/domain/like/repository/LikeRepository.java
+++ b/backend/src/main/java/com/meong9/backend/domain/like/repository/LikeRepository.java
@@ -11,6 +11,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -41,4 +42,18 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
             WHERE pl.member = :member AND pl.pension.pensionId = :pensionId
             """)
     boolean existsByMemberAndPensionId(@Param("member") Member member, @Param("pensionId") Long pensionId);
+
+    @Query("""
+            SELECT pl.place.placeId,
+            CASE
+                WHEN COUNT(pl) > 0
+                THEN true
+                ELSE false
+                END
+            FROM PlaceLike pl
+            WHERE pl.member.memberId = :memberId AND pl.place.placeId IN :placeIds
+            GROUP BY pl.place.placeId
+            """)
+    List<Object[]> findLikeStatusPlaceIds(@Param("memberId") Long memberId, @Param("placeIds") List<Long> placeIds);
+
 }

--- a/backend/src/main/java/com/meong9/backend/domain/like/repository/LikeRepository.java
+++ b/backend/src/main/java/com/meong9/backend/domain/like/repository/LikeRepository.java
@@ -42,18 +42,4 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
             WHERE pl.member = :member AND pl.pension.pensionId = :pensionId
             """)
     boolean existsByMemberAndPensionId(@Param("member") Member member, @Param("pensionId") Long pensionId);
-
-    @Query("""
-            SELECT pl.place.placeId,
-            CASE
-                WHEN COUNT(pl) > 0
-                THEN true
-                ELSE false
-                END
-            FROM PlaceLike pl
-            WHERE pl.member.memberId = :memberId AND pl.place.placeId IN :placeIds
-            GROUP BY pl.place.placeId
-            """)
-    List<Object[]> findLikeStatusPlaceIds(@Param("memberId") Long memberId, @Param("placeIds") List<Long> placeIds);
-
 }

--- a/backend/src/main/java/com/meong9/backend/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/meong9/backend/domain/member/controller/MemberController.java
@@ -33,7 +33,6 @@ public class MemberController {
      */
     @GetMapping("/auth/callback/kakao")
     public ResponseEntity<?> kakaoLogin(@RequestParam(name = "code") String code, HttpServletResponse response) throws IOException {
-        System.out.println("code: " + code);
         LoginResponseDto dto = kakaoService.kakaoLogin(code, response);
         return CommonResponse.ok("success", dto);
     }

--- a/backend/src/main/java/com/meong9/backend/domain/member/dto/LoginResponseDto.java
+++ b/backend/src/main/java/com/meong9/backend/domain/member/dto/LoginResponseDto.java
@@ -10,5 +10,6 @@ public class LoginResponseDto {
     private Long memberId;
     private String email;
     private String nickname;
+    private String profileImageUrl;
     private boolean isNewMember;
 }

--- a/backend/src/main/java/com/meong9/backend/domain/member/service/KakaoService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/member/service/KakaoService.java
@@ -67,25 +67,19 @@ public class KakaoService {
 
     public LoginResponseDto kakaoLogin(String code, HttpServletResponse response) throws IOException {
         // 1. 카카오 액세스 토큰 가져오기
-        log.info("code : " + code);
-        log.info("카카오 code 도착. getToken() 실행");
         String kakaoAccessToken = getToken(code);
 
         // 2. 카카오 사용자 정보 가져오기
-        log.info("카카오 사용자 정보 가져오기 실행");
         KakaoUserInfoDto kakaoUserInfo = getKakaoUserInfo(kakaoAccessToken);
 
         // 3. 회원가입 필요 여부 확인 및 회원 정보 반환
-        log.info("회원가입 필요 여부 확인 및 회원 정보 반환");
         KakaoRegisterResultDto kakaoRegisterResultDto = registerKakaoUserIfNeeded(kakaoUserInfo);
 
         // 4. 로그인 처리
-        log.info("로그인 처리");
         Member kakaoUser = kakaoRegisterResultDto.getMember();
         forceLogin(kakaoUser);
 
         // 5. JWT 토큰 생성 및 응답 헤더 설정
-        log.info("JWT 토큰 생성 및 응답 헤더 설정");
         String accessToken = jwtProvider.createAccessToken(kakaoUser.getEmail(), kakaoUser.getRoleCode());
         response.addHeader(JwtProvider.AUTHORIZATION_HEADER, accessToken);
 
@@ -100,6 +94,7 @@ public class KakaoService {
                 .memberId(kakaoUser.getMemberId())
                 .email(kakaoUser.getEmail())
                 .nickname(kakaoUser.getNickname())
+                .profileImageUrl(kakaoUser.getProfileImage().getFileUrl())
                 .isNewMember(kakaoRegisterResultDto.isNewMember());
         return responseBuilder.build();
     }

--- a/backend/src/main/java/com/meong9/backend/domain/place/entity/PlaceTag.java
+++ b/backend/src/main/java/com/meong9/backend/domain/place/entity/PlaceTag.java
@@ -3,9 +3,9 @@ package com.meong9.backend.domain.place.entity;
 import com.meong9.backend.domain.place.entity.id.PlaceTagKey;
 import com.meong9.backend.global.entity.Tag;
 import jakarta.persistence.*;
-import lombok.*;
-
-import java.io.Serializable;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter

--- a/backend/src/main/java/com/meong9/backend/domain/place/repository/PlaceFileRepository.java
+++ b/backend/src/main/java/com/meong9/backend/domain/place/repository/PlaceFileRepository.java
@@ -1,0 +1,18 @@
+package com.meong9.backend.domain.place.repository;
+
+import com.meong9.backend.domain.place.entity.PlaceFile;
+import com.meong9.backend.domain.place.entity.id.PlaceFileId;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface PlaceFileRepository extends JpaRepository<PlaceFile, PlaceFileId> {
+    @Query("SELECT pf.place.placeId, mf.fileUrl " +
+            "FROM PlaceFile pf " +
+            "JOIN MediaFile mf ON mf.mediaFileId = pf.mediaFile.mediaFileId " +
+            "WHERE pf.place.placeId IN :placeIds")
+    List<Object[]> findImagesByPlaceIds(@Param("placeIds") List<Long> placeIds);
+
+}

--- a/backend/src/main/java/com/meong9/backend/domain/place/repository/PlaceFileRepository.java
+++ b/backend/src/main/java/com/meong9/backend/domain/place/repository/PlaceFileRepository.java
@@ -3,16 +3,7 @@ package com.meong9.backend.domain.place.repository;
 import com.meong9.backend.domain.place.entity.PlaceFile;
 import com.meong9.backend.domain.place.entity.id.PlaceFileId;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-
-import java.util.List;
 
 public interface PlaceFileRepository extends JpaRepository<PlaceFile, PlaceFileId> {
-    @Query("SELECT pf.place.placeId, mf.fileUrl " +
-            "FROM PlaceFile pf " +
-            "JOIN MediaFile mf ON mf.mediaFileId = pf.mediaFile.mediaFileId " +
-            "WHERE pf.place.placeId IN :placeIds")
-    List<Object[]> findImagesByPlaceIds(@Param("placeIds") List<Long> placeIds);
 
 }

--- a/backend/src/main/java/com/meong9/backend/domain/place/repository/PlaceRepository.java
+++ b/backend/src/main/java/com/meong9/backend/domain/place/repository/PlaceRepository.java
@@ -1,15 +1,8 @@
 package com.meong9.backend.domain.place.repository;
 
 import com.meong9.backend.domain.place.entity.Place;
-import com.meong9.backend.domain.search.dto.SearchPlaceDto;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
-
-import java.util.List;
 
 @Repository
 public interface PlaceRepository extends JpaRepository<Place, Long> {

--- a/backend/src/main/java/com/meong9/backend/domain/place/repository/PlaceRepository.java
+++ b/backend/src/main/java/com/meong9/backend/domain/place/repository/PlaceRepository.java
@@ -13,30 +13,5 @@ import java.util.List;
 
 @Repository
 public interface PlaceRepository extends JpaRepository<Place, Long> {
-    @Query("""
-            SELECT new com.meong9.backend.domain.search.dto.SearchPlaceDto(
-            p.placeId,
-            p.name,
-            NULL,
-            p.plcCategory.name,
-            NULL,
-            p.reviewAvg,
-            p.reviewCount,
-            p.enterPetSize,
-            p.businessHour,
-            NULL,
-            NULL)
-            FROM Place p
-            WHERE p.placeId IN :regionCondition
-            AND p.plcCategory.plcCategoryId IN :categoryCondition
-            AND (p.enterPetSize = '030' OR
-            (p.enterPetSize = '020' AND :sizeCode IN ('020', '010')) OR
-            (p.enterPetSize = '010' AND :sizeCode = '010'))
-            """)
-    Slice<SearchPlaceDto> findPlacesByCondition(@Param("regionCondition") List<Long> regionCondition,
-                                                   @Param("categoryCondition") List<Long> categoryCondition,
-                                                   @Param("sizeCode") String sizeCode,
-                                                   Pageable pageable);
-
 
 }

--- a/backend/src/main/java/com/meong9/backend/domain/place/repository/PlaceRepository.java
+++ b/backend/src/main/java/com/meong9/backend/domain/place/repository/PlaceRepository.java
@@ -1,9 +1,42 @@
 package com.meong9.backend.domain.place.repository;
 
 import com.meong9.backend.domain.place.entity.Place;
+import com.meong9.backend.domain.search.dto.SearchPlaceDto;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface PlaceRepository extends JpaRepository<Place, Long> {
+    @Query("""
+            SELECT new com.meong9.backend.domain.search.dto.SearchPlaceDto(
+            p.placeId,
+            p.name,
+            NULL,
+            p.plcCategory.name,
+            NULL,
+            p.reviewAvg,
+            p.reviewCount,
+            p.enterPetSize,
+            p.businessHour,
+            NULL,
+            NULL)
+            FROM Place p
+            WHERE p.placeId IN :regionCondition
+            AND p.plcCategory.plcCategoryId IN :categoryCondition
+            AND (p.enterPetSize = '030' OR
+            (p.enterPetSize = '020' AND :sizeCode IN ('020', '010')) OR
+            (p.enterPetSize = '010' AND :sizeCode = '010'))
+            """)
+    Slice<SearchPlaceDto> findPlacesByCondition(@Param("regionCondition") List<Long> regionCondition,
+                                                   @Param("categoryCondition") List<Long> categoryCondition,
+                                                   @Param("sizeCode") String sizeCode,
+                                                   Pageable pageable);
+
+
 }

--- a/backend/src/main/java/com/meong9/backend/domain/place/repository/PlaceTagRepository.java
+++ b/backend/src/main/java/com/meong9/backend/domain/place/repository/PlaceTagRepository.java
@@ -3,16 +3,7 @@ package com.meong9.backend.domain.place.repository;
 import com.meong9.backend.domain.place.entity.PlaceTag;
 import com.meong9.backend.domain.place.entity.id.PlaceTagKey;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-
-import java.util.List;
 
 public interface PlaceTagRepository extends JpaRepository<PlaceTag, PlaceTagKey> {
-    @Query("SELECT pt.id.placeId, t.name " +
-            "FROM PlaceTag pt " +
-            "JOIN Tag t ON pt.id.tagId = t.tagId " +
-            "WHERE pt.place.placeId IN :placeIds")
-    List<Object[]> findPlaceTagsByPlaceIds(@Param("placeIds") List<Long> placeIds);
 
 }

--- a/backend/src/main/java/com/meong9/backend/domain/place/repository/PlaceTagRepository.java
+++ b/backend/src/main/java/com/meong9/backend/domain/place/repository/PlaceTagRepository.java
@@ -1,0 +1,18 @@
+package com.meong9.backend.domain.place.repository;
+
+import com.meong9.backend.domain.place.entity.PlaceTag;
+import com.meong9.backend.domain.place.entity.id.PlaceTagKey;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface PlaceTagRepository extends JpaRepository<PlaceTag, PlaceTagKey> {
+    @Query("SELECT pt.id.placeId, t.name " +
+            "FROM PlaceTag pt " +
+            "JOIN Tag t ON pt.id.tagId = t.tagId " +
+            "WHERE pt.place.placeId IN :placeIds")
+    List<Object[]> findPlaceTagsByPlaceIds(@Param("placeIds") List<Long> placeIds);
+
+}

--- a/backend/src/main/java/com/meong9/backend/domain/place/repository/PlcCategoryRepository.java
+++ b/backend/src/main/java/com/meong9/backend/domain/place/repository/PlcCategoryRepository.java
@@ -12,4 +12,11 @@ public interface PlcCategoryRepository extends JpaRepository<PlcCategory, Long> 
 
     @Query("SELECT pc FROM PlcCategory pc WHERE pc.name IN :names")
     List<PlcCategory> findAllByNameIn(@Param("names") Set<String> names);
+
+    @Query("SELECT pc.plcCategoryId FROM PlcCategory pc WHERE pc.name IN :placeTypes")
+    List<Long> findPlcCategoryIdsByNameIn(List<String> placeTypes);
+
+    @Query("SELECT pc.plcCategoryId FROM PlcCategory pc")
+    List<Long> findAllCategoryIds();
+
 }

--- a/backend/src/main/java/com/meong9/backend/domain/recommendation/recommendation/service/RecommendationService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/recommendation/recommendation/service/RecommendationService.java
@@ -12,6 +12,7 @@ import com.meong9.backend.domain.recommendation.recommendation.entity.PlaceRecom
 import com.meong9.backend.domain.recommendation.recommendation.repository.PensionRecommendationRepository;
 import com.meong9.backend.domain.recommendation.recommendation.repository.PlaceRecommendationRepository;
 import com.meong9.backend.domain.review.repository.ReviewRepository;
+import com.meong9.backend.global.exception.NotFoundException;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.mahout.cf.taste.impl.model.jdbc.ReloadFromJDBCDataModel;
 import org.apache.mahout.cf.taste.model.DataModel;
@@ -119,12 +120,10 @@ public class RecommendationService {
         List<RecommendationDto> pensionRecommendationList = new ArrayList<>();
 
         for(PensionRecommendation pensionRecommendation : recommendations){
-            PlcPenAddress plcPenAddress= plcPenAddressRepository.findByPlcPenIdAndType(pensionRecommendation.getPensionMemberId().getPensionId(), "020");
-            // 주소 null 체크
-            String address = "";
-            if(plcPenAddress != null){
-                address = plcPenAddress.getAddress().getProvince() + " " + plcPenAddress.getAddress().getCityDistrict();
-            }
+            PlcPenAddress plcPenAddress= plcPenAddressRepository.findByPlcPenIdAndType(pensionRecommendation.getPensionMemberId().getPensionId(), "020")
+                    .orElseThrow(() -> NotFoundException.entityNotFound("시설 주소"));
+
+            String address = plcPenAddress.getAddress().getProvince() + " " + plcPenAddress.getAddress().getCityDistrict();
 
             // 이미지 null 체크
             String img = null;
@@ -170,11 +169,12 @@ public class RecommendationService {
         List<RecommendationDto> placeRecommendationList = new ArrayList<>();
 
         for(PlaceRecommendation placeRecommendation : recommendations){
-            PlcPenAddress plcPenAddress= plcPenAddressRepository.findByPlcPenIdAndType(placeRecommendation.getPlace().getPlaceId(), "010");
+            PlcPenAddress plcPenAddress= plcPenAddressRepository.findByPlcPenIdAndType(placeRecommendation.getPlace().getPlaceId(), "010")
+                    .orElseThrow(() -> NotFoundException.entityNotFound("펜션 주소"));
 
             // 주소 null 체크
             String address = "";
-            if (plcPenAddress != null && plcPenAddress.getAddress() != null) {
+            if (plcPenAddress.getAddress() != null) {
                 address = plcPenAddress.getAddress().getProvince() + " " + plcPenAddress.getAddress().getCityDistrict();
             }
 

--- a/backend/src/main/java/com/meong9/backend/domain/search/controller/SearchController.java
+++ b/backend/src/main/java/com/meong9/backend/domain/search/controller/SearchController.java
@@ -2,6 +2,7 @@ package com.meong9.backend.domain.search.controller;
 
 import com.meong9.backend.domain.member.entity.Member;
 import com.meong9.backend.domain.search.dto.PuppiesForSearchDto;
+import com.meong9.backend.domain.search.dto.SearchPensionsResponseDto;
 import com.meong9.backend.domain.search.dto.SearchPlacesResponseDto;
 import com.meong9.backend.domain.search.service.SearchService;
 import com.meong9.backend.global.annotation.member.CurrentMember;
@@ -43,6 +44,7 @@ public class SearchController {
      */
     @GetMapping("/places")
     public ResponseEntity<?> searchPlaces(
+            @RequestParam(name = "searchWord", required = false) String searchWord,
             @RequestParam(name = "regionList", required = false) List<String> regionList,
             @RequestParam(name = "placeTypes", required = false) List<String> placeTypes,
             @RequestParam(name = "heaviestDogWeight", required = false, defaultValue = "0") double heaviestDogWeight,
@@ -50,8 +52,9 @@ public class SearchController {
             @CurrentMember Member member) {
         Long memberId = (member != null) ? member.getMemberId() : null;
         SearchPlacesResponseDto dto = searchService.searchPlaces(
-                regionList, placeTypes, heaviestDogWeight, pageable, memberId);
+                searchWord, regionList, placeTypes, heaviestDogWeight, pageable, memberId);
         return CommonResponse.ok("success", dto);
     }
+
 
 }

--- a/backend/src/main/java/com/meong9/backend/domain/search/controller/SearchController.java
+++ b/backend/src/main/java/com/meong9/backend/domain/search/controller/SearchController.java
@@ -2,15 +2,21 @@ package com.meong9.backend.domain.search.controller;
 
 import com.meong9.backend.domain.member.entity.Member;
 import com.meong9.backend.domain.search.dto.PuppiesForSearchDto;
+import com.meong9.backend.domain.search.dto.SearchPlacesResponseDto;
 import com.meong9.backend.domain.search.service.SearchService;
 import com.meong9.backend.global.annotation.member.CurrentMember;
 import com.meong9.backend.global.dto.CommonResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @Slf4j
 @RestController
@@ -26,6 +32,25 @@ public class SearchController {
     @GetMapping("/puppies")
     public ResponseEntity<?> getPuppiesForSearch(@CurrentMember Member member) {
         PuppiesForSearchDto dto = searchService.getPuppiesForSearch(member);
+        return CommonResponse.ok("success", dto);
+    }
+
+    /**
+     * 시설 검색 컨트롤러
+     * regionList: 지역 (ex. 서울) (최대 3개)
+     * placeTypes: 장소 카테고리 (ex. 마당) (최대 3개)
+     * heaviestDogWeight: 함께 가고자 하는 강아지들 중 가장 무거운 강아지의 무게
+     */
+    @GetMapping("/places")
+    public ResponseEntity<?> searchPlaces(
+            @RequestParam(name = "regionList", required = false) List<String> regionList,
+            @RequestParam(name = "placeTypes", required = false) List<String> placeTypes,
+            @RequestParam(name = "heaviestDogWeight", required = false, defaultValue = "0") double heaviestDogWeight,
+            @PageableDefault Pageable pageable, // 디폴트 페이지 0, 사이즈 10
+            @CurrentMember Member member) {
+        Long memberId = (member != null) ? member.getMemberId() : null;
+        SearchPlacesResponseDto dto = searchService.searchPlaces(
+                regionList, placeTypes, heaviestDogWeight, pageable, memberId);
         return CommonResponse.ok("success", dto);
     }
 

--- a/backend/src/main/java/com/meong9/backend/domain/search/dto/SearchPlaceDto.java
+++ b/backend/src/main/java/com/meong9/backend/domain/search/dto/SearchPlaceDto.java
@@ -1,0 +1,43 @@
+package com.meong9.backend.domain.search.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+public class SearchPlaceDto {
+    private final Long placeId;
+    private final String placeName;
+    @Setter
+    private String address;
+    private final String placeType;
+    @Setter
+    private List<String> tags;
+    private final Double reviewAvg;
+    private final Integer reviewCount;
+    @Setter
+    private String weightLimit;
+    private final String businessHour;
+    @Setter
+    private List<String> images;
+    @Setter
+    private Boolean LikeStatus;
+
+    @Builder
+    public SearchPlaceDto(Long placeId, String placeName, String address, String placeType, List<String> tags, Double reviewAvg, Integer reviewCount, String weightLimit, String businessHour, List<String> images, Boolean likeStatus) {
+        this.placeId = placeId;
+        this.placeName = placeName;
+        this.address = address;
+        this.placeType = placeType;
+        this.tags = tags;
+        this.reviewAvg = reviewAvg;
+        this.reviewCount = reviewCount;
+        this.weightLimit = weightLimit;
+        this.businessHour = businessHour;
+        this.images = images;
+        LikeStatus = likeStatus;
+    }
+
+}

--- a/backend/src/main/java/com/meong9/backend/domain/search/dto/SearchPlaceDto.java
+++ b/backend/src/main/java/com/meong9/backend/domain/search/dto/SearchPlaceDto.java
@@ -1,43 +1,25 @@
 package com.meong9.backend.domain.search.dto;
 
-import lombok.Builder;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 import java.util.List;
 
 @Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class SearchPlaceDto {
-    private final Long placeId;
-    private final String placeName;
-    @Setter
+    private Long placeId;
+    private String placeName;
     private String address;
-    private final String placeType;
+    private String placeType;
     @Setter
     private List<String> tags;
-    private final Double reviewAvg;
-    private final Integer reviewCount;
-    @Setter
+    private Double reviewAvg;
+    private Integer reviewCount;
     private String weightLimit;
-    private final String businessHour;
+    private String businessHour;
     @Setter
     private List<String> images;
-    @Setter
-    private Boolean LikeStatus;
-
-    @Builder
-    public SearchPlaceDto(Long placeId, String placeName, String address, String placeType, List<String> tags, Double reviewAvg, Integer reviewCount, String weightLimit, String businessHour, List<String> images, Boolean likeStatus) {
-        this.placeId = placeId;
-        this.placeName = placeName;
-        this.address = address;
-        this.placeType = placeType;
-        this.tags = tags;
-        this.reviewAvg = reviewAvg;
-        this.reviewCount = reviewCount;
-        this.weightLimit = weightLimit;
-        this.businessHour = businessHour;
-        this.images = images;
-        LikeStatus = likeStatus;
-    }
+    private Boolean likeStatus;
 
 }

--- a/backend/src/main/java/com/meong9/backend/domain/search/dto/SearchPlacesResponseDto.java
+++ b/backend/src/main/java/com/meong9/backend/domain/search/dto/SearchPlacesResponseDto.java
@@ -1,0 +1,13 @@
+package com.meong9.backend.domain.search.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class SearchPlacesResponseDto {
+    private final List<SearchPlaceDto> placeInfo;
+    private final boolean hasNext;
+}

--- a/backend/src/main/java/com/meong9/backend/domain/search/repository/SearchJooqRepository.java
+++ b/backend/src/main/java/com/meong9/backend/domain/search/repository/SearchJooqRepository.java
@@ -1,0 +1,11 @@
+package com.meong9.backend.domain.search.repository;
+
+import com.meong9.backend.domain.search.dto.SearchPlaceDto;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+import java.util.List;
+
+public interface SearchJooqRepository {
+    Slice<SearchPlaceDto> searchPlaces(List<Long> regionIds, List<Long> categoryIds, String sizeCode, String typeCode, Pageable pageable, Long memberId);
+}

--- a/backend/src/main/java/com/meong9/backend/domain/search/repository/SearchJooqRepository.java
+++ b/backend/src/main/java/com/meong9/backend/domain/search/repository/SearchJooqRepository.java
@@ -8,4 +8,6 @@ import java.util.List;
 
 public interface SearchJooqRepository {
     Slice<SearchPlaceDto> searchPlaces(List<Long> regionIds, List<Long> categoryIds, String sizeCode, String typeCode, Pageable pageable, Long memberId);
+
+    List<Long> findPlaceIdsBySearchWord(String searchWord);
 }

--- a/backend/src/main/java/com/meong9/backend/domain/search/repository/SearchJooqRepositoryImpl.java
+++ b/backend/src/main/java/com/meong9/backend/domain/search/repository/SearchJooqRepositoryImpl.java
@@ -1,9 +1,10 @@
 package com.meong9.backend.domain.search.repository;
 
 import com.meong9.backend.domain.search.dto.SearchPlaceDto;
-import com.meong9.backend.jooq.generated.tables.Address;
 import lombok.RequiredArgsConstructor;
-import org.jooq.*;
+import org.jooq.Condition;
+import org.jooq.DSLContext;
+import org.jooq.Field;
 import org.jooq.impl.DSL;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -29,7 +30,7 @@ public class SearchJooqRepositoryImpl implements SearchJooqRepository {
                         PLACE.PLACE_ID, // placeId
                         PLACE.PLACE_NAME.as("placeName"), // placeName
                         getAddressField(typeCode).as("address"), // address
-                        PLACE.PLC_CATEGORY_ID.as("placeType"), // placeType
+                        PLC_CATEGORY.PLC_CATEGORY_NAME.as("placeType"), // placeType
                         PLACE.REVIEW_AVG, // reviewAverage
                         PLACE.REVIEW_COUNT, // reviewCount
                         PLACE.ENTER_PET_SIZE.as("weightLimit"), // weightLimit
@@ -37,6 +38,7 @@ public class SearchJooqRepositoryImpl implements SearchJooqRepository {
                         getLikeStatusField(memberId) // boolean likeStatus
                 )
                 .from(PLACE)
+                .join(PLC_CATEGORY).on(PLACE.PLC_CATEGORY_ID.eq(PLC_CATEGORY.PLC_CATEGORY_ID))
                 .where(
                         PLACE.PLACE_ID.in(placeIdsByRegion)
                                 .and(PLACE.PLC_CATEGORY_ID.in(categoryIds))
@@ -48,10 +50,10 @@ public class SearchJooqRepositoryImpl implements SearchJooqRepository {
 
         places.forEach(place -> {
             List<String> tags = getTags(place.getPlaceId()); // 태그 조회
-            place.setTags(tags); // DTO에 태그 리스트 설정
+            place.setTags(tags);
 
             List<String> images = getImages(place.getPlaceId()); // 이미지 조회
-            place.setImages(images); // DTO에 이미지 리스트 설정
+            place.setImages(images);
         });
 
         boolean hasNext = places.size() == pageSize;
@@ -101,14 +103,6 @@ public class SearchJooqRepositoryImpl implements SearchJooqRepository {
                 .otherwise(DSL.inline(false))
                 .as("likeStatus");
     }
-
-//    private SelectConditionStep<Record1<Long>> getFilteredPlaceIds(List<Long> regionIds, String typeCode) {
-//        return DSL.select(PLC_PEN_ADDRESS.PLC_PEN_ID)
-//                .from(PLC_PEN_ADDRESS)
-//                .join(ADDRESS).on(PLC_PEN_ADDRESS.PLC_PEN_ID.eq(ADDRESS.ADDRESS_ID))
-//                .where(ADDRESS.REGION_ID.in(regionIds))
-//                .and(PLC_PEN_ADDRESS.TYPE.eq(typeCode));
-//    }
 
     private Condition getWeightCondition(String sizeCode) {
         return PLACE.ENTER_PET_SIZE.eq("030")

--- a/backend/src/main/java/com/meong9/backend/domain/search/repository/SearchJooqRepositoryImpl.java
+++ b/backend/src/main/java/com/meong9/backend/domain/search/repository/SearchJooqRepositoryImpl.java
@@ -11,6 +11,7 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Repository;
 
+import java.util.Arrays;
 import java.util.List;
 
 import static com.meong9.backend.jooq.generated.Tables.*;
@@ -60,6 +61,42 @@ public class SearchJooqRepositoryImpl implements SearchJooqRepository {
 
         return new SliceImpl<>(places, pageable, hasNext);
     }
+
+    @Override
+    public List<Long> findPlaceIdsBySearchWord(String searchWord) {
+        // 검색어를 단어별로 나누어 배열에 담기
+        String[] searchWords = searchWord.split(" ");
+
+        return dsl
+                .selectDistinct(DSL.field("p.place_id", Long.class))
+                .from(
+                        dsl.select(PLACE.PLACE_ID)
+                                .from(PLACE)
+                                .where(
+                                        Arrays.stream(searchWords)
+                                                .map(word -> DSL.condition(
+                                                        "MATCH(place_name, plc_description) AGAINST (? IN BOOLEAN MODE)", word + "*"
+                                                ))
+                                                .reduce(DSL.noCondition(), DSL::or)
+                                )
+                                .asTable("p")
+                )
+                .join(PLC_PEN_ADDRESS).on(DSL.field("p.place_id").eq(PLC_PEN_ADDRESS.PLC_PEN_ID))
+                .join(
+                        dsl.select(ADDRESS.ADDRESS_ID)
+                                .from(ADDRESS)
+                                .where(
+                                        Arrays.stream(searchWords)
+                                                .map(word -> DSL.condition(
+                                                        "MATCH(address, province, city_district, subdistrict) AGAINST (? IN BOOLEAN MODE)", word + "*"
+                                                ))
+                                                .reduce(DSL.noCondition(), DSL::or)
+                                )
+                                .asTable("a")
+                ).on(PLC_PEN_ADDRESS.ADDRESS_ID.eq(DSL.field("a.address_id", Long.class)))
+                .fetchInto(Long.class);
+    }
+
 
     private Field<String> getAddressField(String typeCode) {
         return dsl.select(ADDRESS.ADDRESS_)

--- a/backend/src/main/java/com/meong9/backend/domain/search/repository/SearchJooqRepositoryImpl.java
+++ b/backend/src/main/java/com/meong9/backend/domain/search/repository/SearchJooqRepositoryImpl.java
@@ -1,0 +1,119 @@
+package com.meong9.backend.domain.search.repository;
+
+import com.meong9.backend.domain.search.dto.SearchPlaceDto;
+import com.meong9.backend.jooq.generated.tables.Address;
+import lombok.RequiredArgsConstructor;
+import org.jooq.*;
+import org.jooq.impl.DSL;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.meong9.backend.jooq.generated.Tables.*;
+
+@Repository
+@RequiredArgsConstructor
+public class SearchJooqRepositoryImpl implements SearchJooqRepository {
+
+    private final DSLContext dsl;
+
+    @Override
+    public Slice<SearchPlaceDto> searchPlaces(List<Long> placeIdsByRegion, List<Long> categoryIds, String sizeCode, String typeCode, Pageable pageable, Long memberId) {
+        int offset = (int) pageable.getOffset();
+        int pageSize = pageable.getPageSize();
+
+        List<SearchPlaceDto> places = dsl.select(
+                        PLACE.PLACE_ID, // placeId
+                        PLACE.PLACE_NAME.as("placeName"), // placeName
+                        getAddressField(typeCode).as("address"), // address
+                        PLACE.PLC_CATEGORY_ID.as("placeType"), // placeType
+                        PLACE.REVIEW_AVG, // reviewAverage
+                        PLACE.REVIEW_COUNT, // reviewCount
+                        PLACE.ENTER_PET_SIZE.as("weightLimit"), // weightLimit
+                        PLACE.BUSINESS_HOUR, // businessHour
+                        getLikeStatusField(memberId) // boolean likeStatus
+                )
+                .from(PLACE)
+                .where(
+                        PLACE.PLACE_ID.in(placeIdsByRegion)
+                                .and(PLACE.PLC_CATEGORY_ID.in(categoryIds))
+                                .and(getWeightCondition(sizeCode))
+                )
+                .limit(pageSize)
+                .offset(offset)
+                .fetchInto(SearchPlaceDto.class);
+
+        places.forEach(place -> {
+            List<String> tags = getTags(place.getPlaceId()); // 태그 조회
+            place.setTags(tags); // DTO에 태그 리스트 설정
+
+            List<String> images = getImages(place.getPlaceId()); // 이미지 조회
+            place.setImages(images); // DTO에 이미지 리스트 설정
+        });
+
+        boolean hasNext = places.size() == pageSize;
+
+        return new SliceImpl<>(places, pageable, hasNext);
+    }
+
+    private Field<String> getAddressField(String typeCode) {
+        return dsl.select(ADDRESS.ADDRESS_)
+                .from(PLC_PEN_ADDRESS)
+                .join(ADDRESS).on(PLC_PEN_ADDRESS.ADDRESS_ID.eq(ADDRESS.ADDRESS_ID))
+                .where(PLC_PEN_ADDRESS.PLC_PEN_ID.eq(PLACE.PLACE_ID))
+                .and(PLC_PEN_ADDRESS.TYPE.eq(typeCode))
+                .asField();
+    }
+
+    private List<String> getTags(Long placeId) {
+        return dsl.select(TAG.TAG_NAME)
+                .from(PLACE_TAG)
+                .join(TAG).on(PLACE_TAG.TAG_ID.eq(TAG.TAG_ID))
+                .where(PLACE_TAG.PLACE_ID.eq(placeId))
+                .fetchInto(String.class);
+    }
+
+    private List<String> getImages(Long placeId) {
+        return dsl.select(MEDIA_FILE.FILE_URL)
+                .from(PLACE_FILE)
+                .join(MEDIA_FILE).on(PLACE_FILE.MEDIA_FILE_ID.eq(MEDIA_FILE.MEDIA_FILE_ID))
+                .where(PLACE_FILE.PLACE_ID.eq(placeId))
+                .fetchInto(String.class);
+    }
+
+    private Field<Boolean> getLikeStatusField(Long memberId) {
+        if (memberId == null) {
+            return DSL.inline(false).as("likeStatus");
+        }
+
+        return DSL.when(
+                        DSL.exists(
+                                DSL.selectOne()
+                                        .from(LIKES)
+                                        .where(LIKES.MEMBER_ID.eq(memberId))
+                                        .and(LIKES.PLACE_ID.eq(PLACE.PLACE_ID))
+                        ),
+                        DSL.inline(true)
+                )
+                .otherwise(DSL.inline(false))
+                .as("likeStatus");
+    }
+
+//    private SelectConditionStep<Record1<Long>> getFilteredPlaceIds(List<Long> regionIds, String typeCode) {
+//        return DSL.select(PLC_PEN_ADDRESS.PLC_PEN_ID)
+//                .from(PLC_PEN_ADDRESS)
+//                .join(ADDRESS).on(PLC_PEN_ADDRESS.PLC_PEN_ID.eq(ADDRESS.ADDRESS_ID))
+//                .where(ADDRESS.REGION_ID.in(regionIds))
+//                .and(PLC_PEN_ADDRESS.TYPE.eq(typeCode));
+//    }
+
+    private Condition getWeightCondition(String sizeCode) {
+        return PLACE.ENTER_PET_SIZE.eq("030")
+                .or(PLACE.ENTER_PET_SIZE.eq("020").and(DSL.val(sizeCode).in("020", "010")))
+                .or(PLACE.ENTER_PET_SIZE.eq("010").and(DSL.val(sizeCode).eq("010")));
+    }
+
+}

--- a/backend/src/main/java/com/meong9/backend/domain/search/service/SearchService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/search/service/SearchService.java
@@ -1,24 +1,52 @@
 package com.meong9.backend.domain.search.service;
 
+import com.meong9.backend.domain.address.entity.PlcPenAddress;
+import com.meong9.backend.domain.address.repository.PlcPenAddressRepository;
+import com.meong9.backend.domain.like.repository.LikeRepository;
 import com.meong9.backend.domain.member.entity.Member;
+import com.meong9.backend.domain.pension.entity.PensionFile;
+import com.meong9.backend.domain.place.entity.Place;
+import com.meong9.backend.domain.place.repository.PlaceFileRepository;
+import com.meong9.backend.domain.place.repository.PlaceRepository;
+import com.meong9.backend.domain.place.repository.PlaceTagRepository;
+import com.meong9.backend.domain.place.repository.PlcCategoryRepository;
 import com.meong9.backend.domain.puppy.entity.Puppy;
 import com.meong9.backend.domain.puppy.repository.PuppyRepository;
 import com.meong9.backend.domain.search.dto.PuppiesForSearchDto;
 import com.meong9.backend.domain.search.dto.PuppiesWithWeightDto;
+import com.meong9.backend.domain.search.dto.SearchPlaceDto;
+import com.meong9.backend.domain.search.dto.SearchPlacesResponseDto;
+import com.meong9.backend.global.entity.Tag;
+import com.meong9.backend.global.mediafile.repository.MediaFileRepository;
+import com.meong9.backend.global.mediafile.service.MediaFileService;
+import com.meong9.backend.global.repository.RegionRepository;
+import com.meong9.backend.global.repository.TagRepository;
+import com.meong9.backend.global.utils.EnterPetSizeMapper;
 import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional
+@RequiredArgsConstructor
 public class SearchService {
     private final PuppyRepository puppyRepository;
+    private final RegionRepository regionRepository;
+    private final PlcPenAddressRepository plcPenAddressRepository;
+    private final PlcCategoryRepository plcCategoryRepository;
+    private final PlaceRepository placeRepository;
+    private final PlaceTagRepository placeTagRepository;
+    private final PlaceFileRepository placeFileRepository;
+    private final LikeRepository likeRepository;
 
-    public SearchService(PuppyRepository puppyRepository) {
-        this.puppyRepository = puppyRepository;
-    }
-
+    /**
+     * 멤버의 모든 강아지를 puppyId 기준으로 정렬하여 조회하는 서비스 메서드
+     */
     public PuppiesForSearchDto getPuppiesForSearch(Member member) {
         List<Puppy> puppies = puppyRepository.findByMemberIdWithPuppyProfileImage(member.getMemberId());
         List<PuppiesWithWeightDto> puppiesWithWeightDto = puppies.stream()
@@ -30,5 +58,80 @@ public class SearchService {
                         .build())
                 .toList();
         return new PuppiesForSearchDto(member.getMemberId(), puppiesWithWeightDto);
+    }
+
+    /**
+     * 1) 지역, 2) 장소 카테고리, 3) 강아지 무게 를 기반으로 필터링하여 장소를 검색하는 서비스 메서드
+     */
+    public SearchPlacesResponseDto searchPlaces(List<String> regionList, List<String> placeTypes,
+                                                double heaviestDogWeight, Pageable pageable, Long memberId) {
+        // 1. 지역 조건과 시설 유형 조건으로 시설 ID 조회
+        List<Long> regionIds = (regionList == null || regionList.isEmpty())
+                ? regionRepository.findAllRegionIds()
+                : regionRepository.findRegionIdsByNameIn(regionList);
+
+        String typeCode = "020"; // 시설 코드
+        List<Long> placeIdsByRegion = plcPenAddressRepository.findPlaceIdsByRegionIdIn(regionIds, typeCode);
+
+        // 2. 카테고리 ID 조회
+        List<Long> categoryIds = (placeTypes == null || placeTypes.isEmpty())
+                ? plcCategoryRepository.findAllCategoryIds()
+                : plcCategoryRepository.findPlcCategoryIdsByNameIn(placeTypes);
+
+        // 3. 반려견 체중 조건 추가
+        String sizeCode = heaviestDogWeight < 10 ? "010" : heaviestDogWeight < 25 ? "020" : "030";
+
+        // 4. 최종 필터링된 시설 조회
+        Slice<SearchPlaceDto> filteredPlaces = placeRepository.findPlacesByCondition(placeIdsByRegion, categoryIds, sizeCode, pageable);
+
+        // 5. 결과 DTO로 매핑
+        List<Long> placeIds = filteredPlaces.getContent().stream()
+                .map(SearchPlaceDto::getPlaceId)
+                .collect(Collectors.toList());
+
+        // Address 조회 및 Map 생성
+        Map<Long, String> addressMap = plcPenAddressRepository.findAddressesByPlaceIdsAndType(placeIds, typeCode).stream()
+                .collect(Collectors.toMap(
+                        result -> (Long) result[0], // placeId
+                        result -> (String) result[1] // address
+                ));
+
+        // Tags 조회 및 Map 생성
+        Map<Long, List<String>> tagMap = placeTagRepository.findPlaceTagsByPlaceIds(placeIds).stream()
+                .collect(Collectors.groupingBy(
+                        result -> (Long) result[0], // placeId
+                        Collectors.mapping(result -> (String) result[1], Collectors.toList()) // tags
+                ));
+
+        // Images 조회 및 Map 생성
+        Map<Long, List<String>> imageMap = placeFileRepository.findImagesByPlaceIds(placeIds).stream()
+                .collect(Collectors.groupingBy(
+                        result -> (Long) result[0], // placeId
+                        Collectors.mapping(result -> (String) result[1], Collectors.toList()) // images
+                ));
+
+        // LikeStatus 조회 및 Map 생성
+        Map<Long, Boolean> likedPlaces = memberId == null || placeIds.isEmpty()
+                ? Collections.emptyMap()
+                : likeRepository.findLikeStatusPlaceIds(memberId, placeIds).stream()
+                .collect(Collectors.toMap(
+                        result -> (Long) result[0], // placeId
+                        result -> (Boolean) result[1] // likeStatus
+                ));
+
+        // 6. 병합 및 DTO 생성
+        List<SearchPlaceDto> completedDtos = filteredPlaces.getContent().stream()
+                .map(dto -> {
+                    dto.setWeightLimit(EnterPetSizeMapper.getEnterPetSize(dto.getWeightLimit())); // EnterPetSize 변환 후 재매핑
+                    dto.setAddress(addressMap.getOrDefault(dto.getPlaceId(), null)); // Address 매핑
+                    dto.setTags(tagMap.getOrDefault(dto.getPlaceId(), Collections.emptyList())); // Tags 매핑
+                    dto.setImages(imageMap.getOrDefault(dto.getPlaceId(), Collections.emptyList())); // Images 매핑
+                    dto.setLikeStatus(likedPlaces.getOrDefault(dto.getPlaceId(), false)); // LikeStatus 매핑
+                    return dto;
+                })
+                .collect(Collectors.toList());
+
+        // 7. 응답 생성
+        return new SearchPlacesResponseDto(completedDtos, filteredPlaces.hasNext());
     }
 }

--- a/backend/src/main/java/com/meong9/backend/domain/search/service/SearchService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/search/service/SearchService.java
@@ -1,14 +1,7 @@
 package com.meong9.backend.domain.search.service;
 
-import com.meong9.backend.domain.address.entity.PlcPenAddress;
 import com.meong9.backend.domain.address.repository.PlcPenAddressRepository;
-import com.meong9.backend.domain.like.repository.LikeRepository;
 import com.meong9.backend.domain.member.entity.Member;
-import com.meong9.backend.domain.pension.entity.PensionFile;
-import com.meong9.backend.domain.place.entity.Place;
-import com.meong9.backend.domain.place.repository.PlaceFileRepository;
-import com.meong9.backend.domain.place.repository.PlaceRepository;
-import com.meong9.backend.domain.place.repository.PlaceTagRepository;
 import com.meong9.backend.domain.place.repository.PlcCategoryRepository;
 import com.meong9.backend.domain.puppy.entity.Puppy;
 import com.meong9.backend.domain.puppy.repository.PuppyRepository;
@@ -16,20 +9,18 @@ import com.meong9.backend.domain.search.dto.PuppiesForSearchDto;
 import com.meong9.backend.domain.search.dto.PuppiesWithWeightDto;
 import com.meong9.backend.domain.search.dto.SearchPlaceDto;
 import com.meong9.backend.domain.search.dto.SearchPlacesResponseDto;
-import com.meong9.backend.global.entity.Tag;
-import com.meong9.backend.global.mediafile.repository.MediaFileRepository;
-import com.meong9.backend.global.mediafile.service.MediaFileService;
+import com.meong9.backend.domain.search.repository.SearchJooqRepository;
 import com.meong9.backend.global.repository.RegionRepository;
-import com.meong9.backend.global.repository.TagRepository;
-import com.meong9.backend.global.utils.EnterPetSizeMapper;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.jooq.DSLContext;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.List;
+
+import static com.meong9.backend.jooq.generated.Tables.PLACE;
 
 @Service
 @Transactional
@@ -39,10 +30,8 @@ public class SearchService {
     private final RegionRepository regionRepository;
     private final PlcPenAddressRepository plcPenAddressRepository;
     private final PlcCategoryRepository plcCategoryRepository;
-    private final PlaceRepository placeRepository;
-    private final PlaceTagRepository placeTagRepository;
-    private final PlaceFileRepository placeFileRepository;
-    private final LikeRepository likeRepository;
+    private final SearchJooqRepository searchRepository;
+    private final DSLContext dsl;
 
     /**
      * 멤버의 모든 강아지를 puppyId 기준으로 정렬하여 조회하는 서비스 메서드
@@ -65,7 +54,7 @@ public class SearchService {
      */
     public SearchPlacesResponseDto searchPlaces(List<String> regionList, List<String> placeTypes,
                                                 double heaviestDogWeight, Pageable pageable, Long memberId) {
-        // 1. 지역 조건과 시설 유형 조건으로 시설 ID 조회
+        // 1. 지역 + 카테고리 조건으로 시설 ID 필터링
         List<Long> regionIds = (regionList == null || regionList.isEmpty())
                 ? regionRepository.findAllRegionIds()
                 : regionRepository.findRegionIdsByNameIn(regionList);
@@ -73,65 +62,25 @@ public class SearchService {
         String typeCode = "020"; // 시설 코드
         List<Long> placeIdsByRegion = plcPenAddressRepository.findPlaceIdsByRegionIdIn(regionIds, typeCode);
 
-        // 2. 카테고리 ID 조회
         List<Long> categoryIds = (placeTypes == null || placeTypes.isEmpty())
                 ? plcCategoryRepository.findAllCategoryIds()
                 : plcCategoryRepository.findPlcCategoryIdsByNameIn(placeTypes);
 
-        // 3. 반려견 체중 조건 추가
+        // 2. 반려견 체중 조건 추가
         String sizeCode = heaviestDogWeight < 10 ? "010" : heaviestDogWeight < 25 ? "020" : "030";
 
-        // 4. 최종 필터링된 시설 조회
-        Slice<SearchPlaceDto> filteredPlaces = placeRepository.findPlacesByCondition(placeIdsByRegion, categoryIds, sizeCode, pageable);
+        // 3. 최종 필터링된 시설 조회
+        Slice<SearchPlaceDto> filteredPlaces =
+                searchRepository.searchPlaces(
+                placeIdsByRegion,
+                categoryIds,
+                sizeCode,
+                typeCode,
+                pageable,
+                memberId);
 
-        // 5. 결과 DTO로 매핑
-        List<Long> placeIds = filteredPlaces.getContent().stream()
-                .map(SearchPlaceDto::getPlaceId)
-                .collect(Collectors.toList());
-
-        // Address 조회 및 Map 생성
-        Map<Long, String> addressMap = plcPenAddressRepository.findAddressesByPlaceIdsAndType(placeIds, typeCode).stream()
-                .collect(Collectors.toMap(
-                        result -> (Long) result[0], // placeId
-                        result -> (String) result[1] // address
-                ));
-
-        // Tags 조회 및 Map 생성
-        Map<Long, List<String>> tagMap = placeTagRepository.findPlaceTagsByPlaceIds(placeIds).stream()
-                .collect(Collectors.groupingBy(
-                        result -> (Long) result[0], // placeId
-                        Collectors.mapping(result -> (String) result[1], Collectors.toList()) // tags
-                ));
-
-        // Images 조회 및 Map 생성
-        Map<Long, List<String>> imageMap = placeFileRepository.findImagesByPlaceIds(placeIds).stream()
-                .collect(Collectors.groupingBy(
-                        result -> (Long) result[0], // placeId
-                        Collectors.mapping(result -> (String) result[1], Collectors.toList()) // images
-                ));
-
-        // LikeStatus 조회 및 Map 생성
-        Map<Long, Boolean> likedPlaces = memberId == null || placeIds.isEmpty()
-                ? Collections.emptyMap()
-                : likeRepository.findLikeStatusPlaceIds(memberId, placeIds).stream()
-                .collect(Collectors.toMap(
-                        result -> (Long) result[0], // placeId
-                        result -> (Boolean) result[1] // likeStatus
-                ));
-
-        // 6. 병합 및 DTO 생성
-        List<SearchPlaceDto> completedDtos = filteredPlaces.getContent().stream()
-                .map(dto -> {
-                    dto.setWeightLimit(EnterPetSizeMapper.getEnterPetSize(dto.getWeightLimit())); // EnterPetSize 변환 후 재매핑
-                    dto.setAddress(addressMap.getOrDefault(dto.getPlaceId(), null)); // Address 매핑
-                    dto.setTags(tagMap.getOrDefault(dto.getPlaceId(), Collections.emptyList())); // Tags 매핑
-                    dto.setImages(imageMap.getOrDefault(dto.getPlaceId(), Collections.emptyList())); // Images 매핑
-                    dto.setLikeStatus(likedPlaces.getOrDefault(dto.getPlaceId(), false)); // LikeStatus 매핑
-                    return dto;
-                })
-                .collect(Collectors.toList());
-
-        // 7. 응답 생성
-        return new SearchPlacesResponseDto(completedDtos, filteredPlaces.hasNext());
+        // 4. 반환
+        return new SearchPlacesResponseDto(filteredPlaces.getContent(), filteredPlaces.hasNext());
     }
+
 }

--- a/backend/src/main/java/com/meong9/backend/domain/search/service/SearchService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/search/service/SearchService.java
@@ -48,15 +48,23 @@ public class SearchService {
     /**
      * 1) 지역, 2) 장소 카테고리, 3) 강아지 무게 를 기반으로 필터링하여 장소를 검색하는 서비스 메서드
      */
-    public SearchPlacesResponseDto searchPlaces(List<String> regionList, List<String> placeTypes,
+    public SearchPlacesResponseDto searchPlaces(String searchWord, List<String> regionList, List<String> placeTypes,
                                                 double heaviestDogWeight, Pageable pageable, Long memberId) {
-        // 1. 지역 + 카테고리 조건으로 시설 ID 필터링
-        List<Long> regionIds = (regionList == null || regionList.isEmpty())
-                ? regionRepository.findAllRegionIds()
-                : regionRepository.findRegionIdsByNameIn(regionList);
-
         String typeCode = "020"; // 시설 코드
-        List<Long> placeIdsByRegion = plcPenAddressRepository.findPlaceIdsByRegionIdIn(regionIds, typeCode);
+
+        List<Long> filteredPlaceIds; // 최종 필터링된 시설 ID 목록
+
+        if (searchWord != null && !searchWord.trim().isEmpty()) {
+            // 1. 검색어로 시설 ID 필터링
+            filteredPlaceIds = searchRepository.findPlaceIdsBySearchWord(searchWord);
+        } else {
+            // 2. 지역으로 시설 ID 필터링
+            List<Long> regionIds = (regionList == null || regionList.isEmpty())
+                    ? regionRepository.findAllRegionIds()
+                    : regionRepository.findRegionIdsByNameIn(regionList);
+
+            filteredPlaceIds = plcPenAddressRepository.findPlaceIdsByRegionIdIn(regionIds, typeCode);
+        }
 
         List<Long> categoryIds = (placeTypes == null || placeTypes.isEmpty())
                 ? plcCategoryRepository.findAllCategoryIds()
@@ -68,7 +76,7 @@ public class SearchService {
         // 3. 최종 필터링된 시설 조회
         Slice<SearchPlaceDto> filteredPlaces =
                 searchRepository.searchPlaces(
-                placeIdsByRegion,
+                filteredPlaceIds,
                 categoryIds,
                 sizeCode,
                 typeCode,

--- a/backend/src/main/java/com/meong9/backend/domain/search/service/SearchService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/search/service/SearchService.java
@@ -13,14 +13,11 @@ import com.meong9.backend.domain.search.repository.SearchJooqRepository;
 import com.meong9.backend.global.repository.RegionRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
-import org.jooq.DSLContext;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-
-import static com.meong9.backend.jooq.generated.Tables.PLACE;
 
 @Service
 @Transactional
@@ -31,7 +28,6 @@ public class SearchService {
     private final PlcPenAddressRepository plcPenAddressRepository;
     private final PlcCategoryRepository plcCategoryRepository;
     private final SearchJooqRepository searchRepository;
-    private final DSLContext dsl;
 
     /**
      * 멤버의 모든 강아지를 puppyId 기준으로 정렬하여 조회하는 서비스 메서드

--- a/backend/src/main/java/com/meong9/backend/global/annotation/member/CurrentMemberArgumentResolver.java
+++ b/backend/src/main/java/com/meong9/backend/global/annotation/member/CurrentMemberArgumentResolver.java
@@ -4,6 +4,8 @@ import com.meong9.backend.domain.member.entity.Member;
 import com.meong9.backend.global.auth.entity.MemberDetails;
 import jakarta.validation.constraints.NotNull;
 import org.springframework.core.MethodParameter;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
@@ -24,10 +26,16 @@ public class CurrentMemberArgumentResolver implements HandlerMethodArgumentResol
                                   ModelAndViewContainer mavContainer,
                                   NativeWebRequest webRequest,
                                   WebDataBinderFactory binderFactory) throws Exception {
-        MemberDetails memberDetails = (MemberDetails) SecurityContextHolder
-                .getContext()
-                .getAuthentication()
-                .getPrincipal();
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        // 익명 사용자 처리
+        if (authentication == null || !authentication.isAuthenticated() ||
+                authentication instanceof AnonymousAuthenticationToken) {
+            return null;
+        }
+
+        // 인증된 사용자 처리
+        MemberDetails memberDetails = (MemberDetails) authentication.getPrincipal();
         return memberDetails.member(); // Member 객체를 반환
     }
 }

--- a/backend/src/main/java/com/meong9/backend/global/auth/config/SecurityConfig.java
+++ b/backend/src/main/java/com/meong9/backend/global/auth/config/SecurityConfig.java
@@ -74,7 +74,7 @@ public class SecurityConfig {
         http.authorizeHttpRequests(auth -> auth
                 .requestMatchers(ignoredRequests).permitAll()
                 .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll() // 정적 리소스 허용
-                .requestMatchers(HttpMethod.GET, "/api/v1/search/**", "api/v1/spots/recommendations").permitAll()
+                .requestMatchers(HttpMethod.GET, "/api/v1/search/**", "/api/v1/spots/recommendations").permitAll()
                 .requestMatchers("/index.html", "/favicon.ico").permitAll()
                 .requestMatchers(HttpMethod.GET, "/ping", "/error", "/actuator/health").permitAll() // 헬스 체크 허용
                 .anyRequest().authenticated() // 나머지 요청은 MEMBER 역할 필요

--- a/backend/src/main/java/com/meong9/backend/global/auth/config/SecurityConfig.java
+++ b/backend/src/main/java/com/meong9/backend/global/auth/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.meong9.backend.global.auth.config;
 
+import com.meong9.backend.global.auth.filter.AnonymousAuthenticationFilter;
 import com.meong9.backend.global.auth.filter.JwtAuthenticationFilter;
 import com.meong9.backend.global.auth.service.MemberDetailsService;
 import com.meong9.backend.global.auth.jwt.JwtProvider;
@@ -61,8 +62,6 @@ public class SecurityConfig {
         final RequestMatcher ignoredRequests = new OrRequestMatcher(
                 List.of(new AntPathRequestMatcher("/api/v1/auth/callback/kakao", HttpMethod.GET.name()),
                         new AntPathRequestMatcher("/api/v1/members/check", HttpMethod.GET.name()),
-                        new AntPathRequestMatcher("/api/v1/searches/places", HttpMethod.GET.name()),
-                        new AntPathRequestMatcher("/api/v1/searches/pensions", HttpMethod.GET.name()),
                         new AntPathRequestMatcher("/api/v1/spots/rankings", HttpMethod.GET.name()),
                         new AntPathRequestMatcher("/api/v1/pensions/{pensionId}", HttpMethod.GET.name()),
                         new AntPathRequestMatcher("/api/v1/pensions/{placeId}", HttpMethod.GET.name()),
@@ -75,6 +74,7 @@ public class SecurityConfig {
         http.authorizeHttpRequests(auth -> auth
                 .requestMatchers(ignoredRequests).permitAll()
                 .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll() // 정적 리소스 허용
+                .requestMatchers(HttpMethod.GET, "/api/v1/search/**", "api/v1/spots/recommendations").permitAll()
                 .requestMatchers("/index.html", "/favicon.ico").permitAll()
                 .requestMatchers(HttpMethod.GET, "/ping", "/error", "/actuator/health").permitAll() // 헬스 체크 허용
                 .anyRequest().authenticated() // 나머지 요청은 MEMBER 역할 필요
@@ -91,7 +91,8 @@ public class SecurityConfig {
         http.formLogin(AbstractHttpConfigurer::disable);
 
         http.addFilterBefore(new JwtAuthenticationFilter(jwtProvider, memberDetailsService, ignoredRequests),
-                UsernamePasswordAuthenticationFilter.class);
+                        UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new AnonymousAuthenticationFilter(), JwtAuthenticationFilter.class);
 
         return http.build();
     }

--- a/backend/src/main/java/com/meong9/backend/global/auth/filter/AnonymousAuthenticationFilter.java
+++ b/backend/src/main/java/com/meong9/backend/global/auth/filter/AnonymousAuthenticationFilter.java
@@ -1,0 +1,57 @@
+package com.meong9.backend.global.auth.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.log.LogMessage;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Slf4j(topic = "AnonymousAuthenticationFilter")
+public class AnonymousAuthenticationFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res, FilterChain filterChain) throws ServletException, IOException {
+        if (SecurityContextHolder.getContext().getAuthentication() == null) {
+            Authentication authentication = createAuthentication((HttpServletRequest) req);
+            SecurityContext context = SecurityContextHolder.createEmptyContext();
+            context.setAuthentication(authentication);
+            SecurityContextHolder.setContext(context);
+            if (this.logger.isTraceEnabled()) {
+                this.logger.trace(LogMessage.of(() -> "Set SecurityContextHolder to"
+                        + SecurityContextHolder.getContext().getAuthentication()));
+            } else {
+                this.logger.debug("Set SecurityContextHolder to anonymous SecurityContext");
+            }
+        } else {
+            if (this.logger.isTraceEnabled()) {
+                this.logger.trace(LogMessage.of(() -> "Did not set SecurityContextHolder since already authenticated"
+                        + SecurityContextHolder.getContext().getAuthentication()));
+            }
+        }
+        filterChain.doFilter(req, res);
+    }
+
+    private Authentication createAuthentication(HttpServletRequest request) {
+        // 익명 사용자 principal 설정
+        String anonymousPrincipal = "anonymousUser";
+
+        // 익명 사용자 권한 설정
+        List<GrantedAuthority> authorities = AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS");
+
+        // 익명 사용자 Authentication 객체 생성
+        return new AnonymousAuthenticationToken("anonymousKey", anonymousPrincipal, authorities);
+    }
+}

--- a/backend/src/main/java/com/meong9/backend/global/auth/filter/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/meong9/backend/global/auth/filter/JwtAuthenticationFilter.java
@@ -42,6 +42,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 return;
             }
 
+            if (req.getRequestURI().startsWith("/api/v1/search") || req.getRequestURI().equals("/api/v1/spots/recommendations")) {
+                if (req.getHeader("Authorization") == null) {
+                    filterChain.doFilter(req, res);
+                    return;
+                }
+            }
+
             // 3. Access Token 인증 처리
             String tokenValue = jwtProvider.getTokenFromRequest(req, JwtProvider.AUTHORIZATION_HEADER);
             if (!StringUtils.hasText(tokenValue)) {

--- a/backend/src/main/java/com/meong9/backend/global/config/JooqConfig.java
+++ b/backend/src/main/java/com/meong9/backend/global/config/JooqConfig.java
@@ -1,0 +1,17 @@
+package com.meong9.backend.global.config;
+
+import org.jooq.DSLContext;
+import org.jooq.impl.DSL;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.sql.DataSource;
+
+@Configuration
+public class JooqConfig {
+
+    @Bean
+    public DSLContext dslContext(DataSource dataSource) {
+        return DSL.using(dataSource, org.jooq.SQLDialect.MYSQL);
+    }
+}

--- a/backend/src/main/java/com/meong9/backend/global/repository/RegionRepository.java
+++ b/backend/src/main/java/com/meong9/backend/global/repository/RegionRepository.java
@@ -11,4 +11,10 @@ import java.util.Set;
 public interface RegionRepository extends JpaRepository<Region, Long> {
     @Query("SELECT r FROM Region r WHERE r.name IN :names")
     List<Region> findAllByNameIn(@Param("names") Set<String> newRegionsNames);
+
+    @Query("SELECT r.regionId FROM Region r WHERE r.name IN :regionList")
+    List<Long> findRegionIdsByNameIn(List<String> regionList);
+
+    @Query("SELECT r.regionId FROM Region r")
+    List<Long> findAllRegionIds();
 }

--- a/backend/src/main/java/com/meong9/backend/global/repository/TagRepository.java
+++ b/backend/src/main/java/com/meong9/backend/global/repository/TagRepository.java
@@ -1,0 +1,8 @@
+package com.meong9.backend.global.repository;
+
+import com.meong9.backend.global.entity.Tag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TagRepository extends JpaRepository<Tag, Long> {
+
+}

--- a/backend/src/main/java/com/meong9/backend/global/utils/EnterPetSizeMapper.java
+++ b/backend/src/main/java/com/meong9/backend/global/utils/EnterPetSizeMapper.java
@@ -1,0 +1,16 @@
+package com.meong9.backend.global.utils;
+
+import java.util.Map;
+
+public class EnterPetSizeMapper {
+    private static final Map<String, String> enterPetSizeMap = Map.of(
+            "010", "소형견 가능",
+            "020", "중형견 가능",
+            "030", "대형견 가능"
+    );
+
+    public static String getEnterPetSize(String commonCode) {
+        return enterPetSizeMap.getOrDefault(commonCode, "대형견 가능");
+    }
+
+}

--- a/backend/src/main/java/com/meong9/backend/global/utils/TypeCodeMapper.java
+++ b/backend/src/main/java/com/meong9/backend/global/utils/TypeCodeMapper.java
@@ -1,0 +1,15 @@
+package com.meong9.backend.global.utils;
+
+import java.util.Map;
+
+public class TypeCodeMapper {
+    private static final Map<String, String> typeMap = Map.of(
+            "010", "PENSION",
+            "020", "PLACE"
+    );
+
+    public static String getType(String commonCode) {
+        return typeMap.getOrDefault(commonCode, "PENSION");
+    }
+
+}


### PR DESCRIPTION
## 📋 Summary
<!-- 이 PR에서 변경된 주요 내용을 간략히 작성해주세요. -->
- 시큐리티 Role_Anonymous 추가
- 장소 검색 시 Jooq 사용

## ✨ Feature Details
| Method | Path                      | Description      |
|--------|---------------------------|------------------|
| GET   | /api/v1/search/places | 장소 검색        |


## 💡 Key Considerations
<!-- 구현하면서 고려한 점, 또는 해결한 주요 이슈를 간단히 작성해주세요. -->
1. 시큐리티 Role_Anonymous추가
- 검색 결과에는 '좋아요 여부'가 포함되어야 한다. 이를 위해서는 반드시 로그인을 해야 하지만, 인증되지 않은 사용자도 검색을 이용할 수 있어야 한다. 
- 시큐리티 필터를 그냥 통과하게 만들면, 시큐리티는 로그인한 사용자의 인증 객체를 들고오지 못한다. 즉, 좋아요 여부를 판별할 수 없다. 
- 시큐리티 필터를 타게 만들면, 로그인 안 한 사용자는 검색을 이용할 수 없다. 
- 따라서, Anonymous Authentication Filter를 구현하여 로그인하지 않은 사용자에게도 Role을 부여한다. 
- 이를 통해 시큐리티 필터를 타게 하면서, 로그인한 사용자의 인증 객체를 들고오도록 한다. 
- 로그인하지 않은 사용자는 값이 Null인 Authentication 객체를 지닌다. 따라서 memberId 또한 Null이며, 검색 시 memberId가 null일 경우 바로 좋아요 여부 false를 반환하게 한다. 

2. 검색에 Jooq 도입 
- JPQL을 사용하여 쿼리를 작성하던 중, 여러 테이블을 건드리며 장소에 대한 정보를 들고와야 했다. 
- 쿼리가 20줄이 넘어가고, 어디서 에러가 터지는지, 반환타입은 제대로 맞는 건지 알 수 없었으며, 런타임 시에만 이를 확인할 수 있어 새로운 방법을 물색하였다. 
- 컴파일 타임 시 타입 안전한 쿼리를 작성할 수 있는 후보는 query dsl과 jooq가 있었다. 
- query dsl은 jpa와 연동이 잘 되고 jpa의 1차 캐시 등의 기능을 활용할 수 있다는 점이 좋지만 업데이트가 점점 늦어지고 사장되어 가고 있다는 말이 많다. 
- jooq는 query dsl의 대체제로, sql 빌더 api를 제공한다. 업데이트가 빠른 편이며 spring boot starter jooq를 제공하는 등 스프링부트와의 연동도 좋다. 
- 이번 프로젝트는 이전에 사용해봤던 query dsl과의 차이점, 더불어 mysql의 full-text 서치처럼 dbms의 고유한 기능을 이용할 수 있다는 jooq의 장점을 느껴보기 위해 jooq를 도입하였다.

- 하지만 엔티티와 RDBMS 스키마가 맞지 않을 시, 에러가 수정될 때까지 서버가 동작하지 않으며,  
- 빌드 시간 또한 확실히 느려지는 걸 알 수 있었다. 
- 추후 수정이 필요하면 다른 방법을 물색해 볼 예정! 

## ✅ Checklist
- [X] 코드를 스스로 검토했나요?
- [X] 필요한 테스트를 추가하고 모두 통과했나요?
- [X] 브랜치 전략에 맞는 브랜치에 PR을 올렸나요?
- [X] 커밋 메시지가 컨벤션에 맞나요?
- [X] 필요한 문서를 업데이트했나요?
