### PR TITLE
From Kan-85-BE-feat/map-info into dev : 찜한 장소 목록 조회

### DIFF
--- a/backend/src/main/java/com/meong9/backend/domain/like/entity/PensionLike.java
+++ b/backend/src/main/java/com/meong9/backend/domain/like/entity/PensionLike.java
@@ -4,11 +4,13 @@ import com.meong9.backend.domain.member.entity.Member;
 import com.meong9.backend.domain.pension.entity.Pension;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @DiscriminatorValue("Pension")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 public class PensionLike extends Like{
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "pension_id")

--- a/backend/src/main/java/com/meong9/backend/domain/like/entity/PlaceLike.java
+++ b/backend/src/main/java/com/meong9/backend/domain/like/entity/PlaceLike.java
@@ -11,6 +11,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @DiscriminatorValue("Place")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 public class PlaceLike extends Like{
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/backend/src/main/java/com/meong9/backend/domain/like/repository/LikeRepository.java
+++ b/backend/src/main/java/com/meong9/backend/domain/like/repository/LikeRepository.java
@@ -42,4 +42,18 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
             WHERE pl.member = :member AND pl.pension.pensionId = :pensionId
             """)
     boolean existsByMemberAndPensionId(@Param("member") Member member, @Param("pensionId") Long pensionId);
+
+    // 찜 펜션 목록 조회
+    @Query("SELECT pl FROM PensionLike pl " +
+            "JOIN FETCH pl.pension pen " +
+            "WHERE pl.member = :member")
+    List<PensionLike> findAllPensionLikes(@Param("member") Member member);
+
+    // 찜 시설 목록 조회
+    @Query("SELECT pl FROM PlaceLike pl " +
+            "JOIN FETCH pl.place pla " +
+            "WHERE pl.member = :member")
+    List<PlaceLike> findAllPlaceLikes(@Param("member") Member member);
+
+
 }

--- a/backend/src/main/java/com/meong9/backend/domain/map/controller/MapController.java
+++ b/backend/src/main/java/com/meong9/backend/domain/map/controller/MapController.java
@@ -1,0 +1,48 @@
+package com.meong9.backend.domain.map.controller;
+
+import com.meong9.backend.domain.map.dto.MapLikePointDto;
+import com.meong9.backend.domain.map.service.MapService;
+import com.meong9.backend.global.dto.CommonResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/map")
+@RequiredArgsConstructor
+public class MapController {
+
+    private final MapService mapService;
+
+    // 카테고리 별 찜 상세 조회
+//    @GetMapping("/likes/detail")
+//    public ResponseEntity<?> getMapLikeDetails(){
+//
+//    }
+
+    // 장소 검색
+//    @GetMapping("/search")
+//    public ResponseEntity<?> getSearchPlcPen(@RequestParam(name = "keyword") String keyword){
+//
+//    }
+
+    // 찜한 장소 위도, 경도 조회 (마커용)
+    @GetMapping("/likes/points")
+    public ResponseEntity<?> getMapLikePoints(){
+        List<MapLikePointDto> mapPointList = mapService.getMapLikePoints();
+
+        return CommonResponse.ok("success", mapPointList);
+    }
+
+    // 장소 조회
+//    @GetMapping("/places")
+//    public ResponseEntity<?> getSelectPlcPen(){
+//
+//    }
+}

--- a/backend/src/main/java/com/meong9/backend/domain/map/controller/MapController.java
+++ b/backend/src/main/java/com/meong9/backend/domain/map/controller/MapController.java
@@ -2,6 +2,8 @@ package com.meong9.backend.domain.map.controller;
 
 import com.meong9.backend.domain.map.dto.MapLikePointDto;
 import com.meong9.backend.domain.map.service.MapService;
+import com.meong9.backend.domain.member.entity.Member;
+import com.meong9.backend.global.annotation.member.CurrentMember;
 import com.meong9.backend.global.dto.CommonResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -21,28 +23,27 @@ public class MapController {
     private final MapService mapService;
 
     // 카테고리 별 찜 상세 조회
-//    @GetMapping("/likes/detail")
-//    public ResponseEntity<?> getMapLikeDetails(){
-//
-//    }
+    @GetMapping("/likes/detail")
+    public ResponseEntity<?> getMapLikeDetails(){
+        return CommonResponse.ok("success", null);
+    }
 
     // 장소 검색
-//    @GetMapping("/search")
-//    public ResponseEntity<?> getSearchPlcPen(@RequestParam(name = "keyword") String keyword){
-//
-//    }
+    @GetMapping("/search")
+    public ResponseEntity<?> getSearchPlcPen(@RequestParam(name = "keyword") String keyword){
+        return CommonResponse.ok("success", null);
+    }
 
     // 찜한 장소 위도, 경도 조회 (마커용)
     @GetMapping("/likes/points")
-    public ResponseEntity<?> getMapLikePoints(){
-        List<MapLikePointDto> mapPointList = mapService.getMapLikePoints();
+    public ResponseEntity<?> getMapLikePoints(@CurrentMember Member member){
+        List<MapLikePointDto> mapPointList = mapService.getMapLikePoints(member);
 
         return CommonResponse.ok("success", mapPointList);
     }
-
     // 장소 조회
-//    @GetMapping("/places")
-//    public ResponseEntity<?> getSelectPlcPen(){
-//
-//    }
+    @GetMapping("/places")
+    public ResponseEntity<?> getSelectPlcPen(){
+        return CommonResponse.ok("success", null);
+    }
 }

--- a/backend/src/main/java/com/meong9/backend/domain/map/dto/MapLikePointDto.java
+++ b/backend/src/main/java/com/meong9/backend/domain/map/dto/MapLikePointDto.java
@@ -1,0 +1,15 @@
+package com.meong9.backend.domain.map.dto;
+
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class MapLikePointDto {
+    private Long id; // 펜션, 시설 아이디
+    private String type; // 펜션, 시설 타입
+    private String name; // 이름
+    private String latitude; // 위도
+    private String longitude; // 경도
+}

--- a/backend/src/main/java/com/meong9/backend/domain/map/service/MapService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/map/service/MapService.java
@@ -1,23 +1,57 @@
 package com.meong9.backend.domain.map.service;
 
+import com.meong9.backend.domain.like.entity.Like;
+import com.meong9.backend.domain.like.entity.PensionLike;
+import com.meong9.backend.domain.like.entity.PlaceLike;
 import com.meong9.backend.domain.like.repository.LikeRepository;
 import com.meong9.backend.domain.map.dto.MapLikePointDto;
+import com.meong9.backend.domain.member.entity.Member;
+import com.meong9.backend.jooq.generated.tables.Likes;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class MapService {
 
-    private LikeRepository likeRepository;
+    private final LikeRepository likeRepository;
 
     // 찜 마커
     @Transactional(readOnly = true)
-    public List<MapLikePointDto> getMapLikePoints() {
-//        likeRepository.findAll
-        return null;
+    public List<MapLikePointDto> getMapLikePoints(Member member) {
+        List<PensionLike> pensionLikes = likeRepository.findAllPensionLikes(member);
+        List<PlaceLike> placeLikes = likeRepository.findAllPlaceLikes(member);
+
+        // dto 매핑
+        List<MapLikePointDto> mapLikePointList = new ArrayList<>();
+        for(PensionLike pensionLike : pensionLikes){
+            MapLikePointDto mapLikePointDto = MapLikePointDto.builder()
+                    .id(pensionLike.getPension().getPensionId())
+                    .type("펜션")
+                    .name(pensionLike.getPension().getName())
+                    .latitude(pensionLike.getPension().getLatitude())
+                    .longitude(pensionLike.getPension().getLongitude())
+                    .build();
+
+            mapLikePointList.add(mapLikePointDto);
+        }
+
+        for(PlaceLike placeLike : placeLikes){
+            MapLikePointDto mapLikePointDto = MapLikePointDto.builder()
+                    .id(placeLike.getPlace().getPlaceId())
+                    .type("시설")
+                    .name(placeLike.getPlace().getName())
+                    .latitude(placeLike.getPlace().getLatitude())
+                    .longitude(placeLike.getPlace().getLongitude())
+                    .build();
+
+            mapLikePointList.add(mapLikePointDto);
+        }
+
+        return mapLikePointList;
     }
 }

--- a/backend/src/main/java/com/meong9/backend/domain/map/service/MapService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/map/service/MapService.java
@@ -1,0 +1,23 @@
+package com.meong9.backend.domain.map.service;
+
+import com.meong9.backend.domain.like.repository.LikeRepository;
+import com.meong9.backend.domain.map.dto.MapLikePointDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MapService {
+
+    private LikeRepository likeRepository;
+
+    // 찜 마커
+    @Transactional(readOnly = true)
+    public List<MapLikePointDto> getMapLikePoints() {
+//        likeRepository.findAll
+        return null;
+    }
+}


### PR DESCRIPTION
## 📋 Summary
<!-- 이 PR에서 변경된 주요 내용을 간략히 작성해주세요. -->
찜한 장소 목록 조회

## ✨ Feature Details
| Method | Path                      | Description      |
|--------|---------------------------|------------------|
| GET | /api/v1/map/likes/points | 찜한 장소 조회  |


## 💡 Key Considerations
<!-- 구현하면서 고려한 점, 또는 해결한 주요 이슈를 간단히 작성해주세요. -->
그냥 고민했던 부분인데... 펜션 좋아요, 시설 좋아요 따로 가져왔는데 현재 like 테이블 구조에서 한번에 가져올 수 있는 방법이 있는지 궁금해요!
그리고 아직 db에 펜션 위도,경도 값은 없습니당
수정 부분 안겹쳐서 일단 pr 올려봄

![image](https://github.com/user-attachments/assets/14b7ca6f-f859-470d-ac64-c06786112611)


## ✅ Checklist
- [x] 코드를 스스로 검토했나요?
- [x] 필요한 테스트를 추가하고 모두 통과했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올렸나요?
- [x] 커밋 메시지가 컨벤션에 맞나요?
- [x] 필요한 문서를 업데이트했나요?
