### PR TITLE
From  KAN-93-BE-refactor/transaction into dev: 멤버 관련 리팩토링 및 시큐리티 설정 수정

### DIFF
--- a/backend/src/main/java/com/meong9/backend/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/meong9/backend/domain/member/controller/MemberController.java
@@ -2,77 +2,28 @@ package com.meong9.backend.domain.member.controller;
 
 import com.meong9.backend.domain.member.dto.*;
 import com.meong9.backend.domain.member.entity.Member;
-import com.meong9.backend.domain.member.service.KakaoService;
 import com.meong9.backend.domain.member.service.MemberService;
 import com.meong9.backend.global.annotation.member.CurrentMember;
-import com.meong9.backend.global.auth.jwt.JwtProvider;
 import com.meong9.backend.global.dto.CommonResponse;
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
-import java.util.Map;
 
-@Slf4j
 @RestController
-@RequestMapping("/api/v1")
+@RequestMapping("/api/v1/members")
 @RequiredArgsConstructor
 public class MemberController {
-    private final KakaoService kakaoService;
+
     private final MemberService memberService;
-
-    /**
-     * 카카오 로그인 처리 컨트롤러
-     */
-    @GetMapping("/auth/callback/kakao")
-    public ResponseEntity<?> kakaoLogin(@RequestParam(name = "code") String code, HttpServletResponse response) throws IOException {
-        LoginResponseDto dto = kakaoService.kakaoLogin(code, response);
-        return CommonResponse.ok("success", dto);
-    }
-
-    /**
-     * access token 재발급 요청 처리 컨트롤러
-     */
-    @PostMapping("/auth/token")
-    public ResponseEntity<?> refreshAccessToken(@CookieValue(name = "Refresh-token") String refreshToken) {
-        String newAccessToken = memberService.refreshAccessToken(refreshToken);
-
-        HttpHeaders headers = new HttpHeaders();
-        headers.set(JwtProvider.AUTHORIZATION_HEADER, newAccessToken);
-
-        return ResponseEntity.ok()
-                .headers(headers)
-                .body(Map.of("message", "Access Token이 재발급되었습니다."));
-    }
-
-    /**
-     * 로그아웃 처리 컨트롤러
-     */
-    @PostMapping("/auth/logout")
-    public ResponseEntity<?> logout(@CookieValue(name = "Refresh-token") String refreshToken,
-                                    HttpServletResponse response) {
-        memberService.logout(refreshToken);
-        Cookie cookie = new Cookie(JwtProvider.REFRESH_TOKEN_HEADER, "");
-        cookie.setPath("/");
-        cookie.setHttpOnly(true);
-        cookie.setSecure(true);
-        cookie.setAttribute("SameSite", "None");
-        cookie.setMaxAge(0);
-        response.addCookie(cookie);
-        return CommonResponse.ok("success");
-    }
 
     /**
      * 회원 선호시설 추가 컨트롤러
      */
-    @PostMapping("/members/interests/places")
+    @PostMapping("/interests/places")
     public ResponseEntity<?> insertPreferredPlaces(@RequestBody InterestDto dto,
                                                    @CurrentMember Member member) {
         memberService.insertPreferredPlaces(dto, member);
@@ -82,7 +33,7 @@ public class MemberController {
     /**
      * 회원 선호지역 추가 컨트롤러
      */
-    @PostMapping("/members/interests/regions")
+    @PostMapping("/interests/regions")
     public ResponseEntity<?> insertPreferredRegions(@RequestBody RegionDto dto,
                                                     @CurrentMember Member member) {
         memberService.insertPreferredRegions(dto, member);
@@ -92,7 +43,7 @@ public class MemberController {
     /**
      * 회원 정보 등록 요청 컨트롤러
      */
-    @PostMapping("/members/info")
+    @PostMapping("/info")
     public ResponseEntity<?> insertMemberInfo(@RequestPart(name = "ProfileImage", required = false) MultipartFile profileImage,
                                               @Valid @RequestPart(name = "MemberInfoDto") MemberInfoDto dto,
                                               @CurrentMember Member member) throws IOException {
@@ -103,7 +54,7 @@ public class MemberController {
     /**
      * 프로필 사진 삭제 요청 컨트롤러
      */
-    @DeleteMapping("/members/images")
+    @DeleteMapping("/images")
     public ResponseEntity<?> deleteProfileImage(@CurrentMember Member member) {
         memberService.deleteProfileImage(member);
         return CommonResponse.ok("success");
@@ -112,7 +63,7 @@ public class MemberController {
     /**
      * 닉네임 중복 여부 확인 컨트롤러
      */
-    @GetMapping("/members/check")
+    @GetMapping("/check")
     public ResponseEntity<?> checkNicknameAvailability(@RequestParam(name = "nickname") String nickname) {
         boolean isAvailable = memberService.isNicknameAvailable(nickname);
         String message = isAvailable ? "사용 가능한 닉네임입니다." : "중복된 닉네임입니다.";
@@ -122,7 +73,7 @@ public class MemberController {
     /**
      * 마이페이지 조회 컨트롤러
      */
-    @GetMapping("/members")
+    @GetMapping
     public ResponseEntity<?> getMyPage(@CurrentMember Member member) {
         MypageDto dto = memberService.getMyPage(member);
         return CommonResponse.ok("success", dto);
@@ -131,7 +82,7 @@ public class MemberController {
     /**
      * 마이페이지 상세 조회 컨트롤러
      */
-    @GetMapping("/members/detail")
+    @GetMapping("/detail")
     public ResponseEntity<?> getMyPageDetail(@CurrentMember Member member) {
         MyPageDetailDto dto = memberService.getMyPageDetail(member);
         return CommonResponse.ok("success", dto);
@@ -140,7 +91,7 @@ public class MemberController {
     /**
      * 마이페이지 수정 컨트롤러
      */
-    @PatchMapping("/members")
+    @PatchMapping
     public ResponseEntity<?> updateMyPage(@RequestPart(name = "ProfileImage", required = false) MultipartFile profileImage,
                                           @Valid @RequestPart(name = "UpdateMyPageRequestDto") MemberInfoDto requestDto,
                                           @CurrentMember Member member) throws IOException {
@@ -151,7 +102,7 @@ public class MemberController {
     /**
      * 선호 지역 조회 컨트롤러
      */
-    @GetMapping("/members/interests/regions")
+    @GetMapping("/interests/regions")
     public ResponseEntity<?> getPreferredRegions(@CurrentMember Member member){
         RegionDto dto = memberService.getPreferredRegions(member);
         return CommonResponse.ok("success", dto);
@@ -160,7 +111,7 @@ public class MemberController {
     /**
      * 선호 지역 수정 컨트롤러
      */
-    @PatchMapping("/members/interests/regions")
+    @PatchMapping("/interests/regions")
     public ResponseEntity<?> updatePreferredRegions(@RequestBody RegionDto regionDto,
                                                     @CurrentMember Member member){
         memberService.insertPreferredRegions(regionDto, member);
@@ -170,7 +121,7 @@ public class MemberController {
     /**
      * 선호 시설 조회 컨트롤러
      */
-    @GetMapping("/members/interests/places")
+    @GetMapping("/interests/places")
     public ResponseEntity<?> getPreferredPlaces(@CurrentMember Member member){
         InterestDto dto = memberService.getPreferredPlaces(member);
         return CommonResponse.ok("success", dto);
@@ -179,7 +130,7 @@ public class MemberController {
     /**
      * 선호 시설 수정 컨트롤러
      */
-    @PatchMapping("/members/interests/places")
+    @PatchMapping("/interests/places")
     public ResponseEntity<?> updatePreferredPlaces(@RequestBody InterestDto interestDto,
                                                    @CurrentMember Member member){
         memberService.insertPreferredPlaces(interestDto, member);

--- a/backend/src/main/java/com/meong9/backend/domain/member/entity/Member.java
+++ b/backend/src/main/java/com/meong9/backend/domain/member/entity/Member.java
@@ -25,7 +25,7 @@ public class Member extends BaseTimeEntity {
     @Setter
     private String name;
 
-    @Column(nullable = false, length = 20, unique = true)
+    @Column(length = 20, unique = true)
     @Setter
     private String nickname;
 

--- a/backend/src/main/java/com/meong9/backend/domain/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/meong9/backend/domain/member/repository/MemberRepository.java
@@ -1,6 +1,7 @@
 package com.meong9.backend.domain.member.repository;
 
 import com.meong9.backend.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -12,16 +13,14 @@ import java.util.Optional;
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
 
+    @EntityGraph(attributePaths = "profileImage")
     Optional<Member> findByProviderId(String providerId);
 
     @Query("SELECT m.memberId FROM Member m WHERE m.lastActivity >= :week")
     List<Long> findActiveMembers(@Param("week") LocalDateTime week);
 
-
     boolean existsByNickname(String nickname);
 
     @Query("SELECT m FROM Member m JOIN FETCH m.profileImage WHERE m.memberId = :memberId")
     Optional<Member> findMemberWithProfileImage(Long memberId);
-    @Query("select m.memberId from Member m where m.memberId <= :i")
-    List<Long> findByMemberId(int i);
 }

--- a/backend/src/main/java/com/meong9/backend/domain/member/service/KakaoService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/member/service/KakaoService.java
@@ -44,7 +44,6 @@ import java.time.LocalDateTime;
 
 @Slf4j(topic = "KAKAO Login")
 @Service
-@Transactional
 @RequiredArgsConstructor
 public class KakaoService {
 
@@ -66,6 +65,7 @@ public class KakaoService {
 
     public static final String PROVIDER_KAKAO = "KAKAO";
 
+    @Transactional
     public LoginResponseDto kakaoLogin(String code, HttpServletResponse response) throws IOException {
         // 1. 카카오 액세스 토큰 가져오기
         String kakaoAccessToken = getToken(code);
@@ -187,7 +187,8 @@ public class KakaoService {
         }
     }
 
-    private KakaoRegisterResultDto registerKakaoUserIfNeeded(KakaoUserInfoDto kakaoUserInfo) {
+    @Transactional
+    protected KakaoRegisterResultDto registerKakaoUserIfNeeded(KakaoUserInfoDto kakaoUserInfo) {
         // 1. 기존 카카오 회원 확인
         Member kakaoUser = memberRepository.findByProviderId(kakaoUserInfo.getId()).orElse(null);
         if (kakaoUser != null) {
@@ -247,11 +248,10 @@ public class KakaoService {
                 .build();
     }
 
-    private Authentication forceLogin(Member kakaoUser) {
+    private void forceLogin(Member kakaoUser) {
         UserDetails userDetails = new MemberDetails(kakaoUser);
         Authentication authentication = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
         SecurityContextHolder.getContext().setAuthentication(authentication);
-        return authentication;
     }
 
 }

--- a/backend/src/main/java/com/meong9/backend/domain/member/service/KakaoService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/member/service/KakaoService.java
@@ -106,7 +106,6 @@ public class KakaoService {
 
     private String getToken(String code) throws JsonProcessingException {
         try {
-            log.info("인가코드: " + code);
             // 요청 URL 만들기
             URI uri = UriComponentsBuilder
                     .fromUriString("https://kauth.kakao.com")
@@ -217,30 +216,31 @@ public class KakaoService {
         Member savedMember = memberRepository.save(kakaoUser);
 
         // 4. S3에 프로필 사진 업로드 및 DB 저장
-        S3UploadResultDto s3UploadResultDto = mediaFileService.uploadFromUrl(
-                kakaoUserInfo.getProfileImageUrl(),
-                savedMember.getMemberId(),
-                "Mprofile/",
-                "_profile.jpg"
-        );
+        try {
+            S3UploadResultDto s3UploadResultDto = mediaFileService.uploadFromUrl(
+                    kakaoUserInfo.getProfileImageUrl(),
+                    savedMember.getMemberId(),
+                    "Mprofile/",
+                    "_profile.jpg"
+            );
 
-        ImageMetadataDto metadata = mediaFileService.extractImageMetadataFromUrl(kakaoUserInfo.getProfileImageUrl());
+            ImageMetadataDto metadata = mediaFileService.extractImageMetadataFromUrl(kakaoUserInfo.getProfileImageUrl());
+            MediaFile mediaFile = MediaFile.builder()
+                    .fileType(FileType.IMAGE)
+                    .fileSize((int) metadata.getFileSize())
+                    .fileName("profile.jpg")
+                    .fileUrl(s3UploadResultDto.getS3Url())
+                    .height((double) metadata.getHeight())
+                    .width((double) metadata.getWidth())
+                    .fileKey(s3UploadResultDto.getFileKey())
+                    .build();
 
-        MediaFile mediaFile = MediaFile.builder()
-                .fileType(FileType.IMAGE)
-                .fileSize((int) metadata.getFileSize())
-                .fileName("profile.jpg")
-                .fileUrl(s3UploadResultDto.getS3Url())
-                .height((double) metadata.getHeight())
-                .width((double) metadata.getWidth())
-                .fileKey(s3UploadResultDto.getFileKey())
-                .build();
-
-        mediaFileRepository.save(mediaFile);
-
-        // 5. 멤버 업데이트 (프로필 이미지 연결)
-        savedMember.setProfileImage(mediaFile);
-        memberRepository.save(savedMember);
+            mediaFileRepository.save(mediaFile);
+            savedMember.setProfileImage(mediaFile);
+        } catch (Exception e) {
+            // S3에 업로드 실패 시, 프로필 이미지를 제외한 나머지 회원 정보를 저장 + 프로필 이미지는 기본 이미지를 활용한다
+            savedMember.setProfileImage(mediaFileService.createDefaultProfileImage());
+        }
 
         return KakaoRegisterResultDto.builder()
                 .isNewMember(true)

--- a/backend/src/main/java/com/meong9/backend/domain/member/service/KakaoService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/member/service/KakaoService.java
@@ -82,7 +82,6 @@ public class KakaoService {
 
         // 최근 활동 필드 업데이트
         kakaoUser.setLastActivity(LocalDateTime.now());
-        memberRepository.save(kakaoUser);
 
         // 5. JWT 토큰 생성 및 응답 헤더 설정
         String accessToken = jwtProvider.createAccessToken(kakaoUser.getEmail(), kakaoUser.getRoleCode());
@@ -188,7 +187,7 @@ public class KakaoService {
         }
     }
 
-    private KakaoRegisterResultDto registerKakaoUserIfNeeded(KakaoUserInfoDto kakaoUserInfo) throws IOException {
+    private KakaoRegisterResultDto registerKakaoUserIfNeeded(KakaoUserInfoDto kakaoUserInfo) {
         // 1. 기존 카카오 회원 확인
         Member kakaoUser = memberRepository.findByProviderId(kakaoUserInfo.getId()).orElse(null);
         if (kakaoUser != null) {

--- a/backend/src/main/java/com/meong9/backend/domain/meongPhoto/controller/MeongPhotoController.java
+++ b/backend/src/main/java/com/meong9/backend/domain/meongPhoto/controller/MeongPhotoController.java
@@ -14,8 +14,6 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.IOException;
-
 @Slf4j
 @RestController
 @RequestMapping("/api/v1/photos")

--- a/backend/src/main/java/com/meong9/backend/global/auth/config/SecurityConfig.java
+++ b/backend/src/main/java/com/meong9/backend/global/auth/config/SecurityConfig.java
@@ -45,7 +45,8 @@ public class SecurityConfig {
     @Bean
     CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedHeaders(List.of("*"));
+//        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setAllowedHeaders(List.of("Authorization", "Content-Type"));
         configuration.setAllowedOrigins(List.of("http://localhost:5173", "http://localhost:3000", "http://localhost:8080"));
         configuration.setAllowCredentials(true);
         configuration.setAllowedMethods(Arrays.asList("GET","POST","PUT", "PATCH", "DELETE","OPTIONS"));
@@ -69,7 +70,8 @@ public class SecurityConfig {
                         new AntPathRequestMatcher("/api/v1/pensions/{placeId}", HttpMethod.GET.name()),
                         new AntPathRequestMatcher("/api/v1/pensions/{placeId}/reviews", HttpMethod.GET.name()),
                         new AntPathRequestMatcher("/", HttpMethod.GET.name()),
-                        new AntPathRequestMatcher("/actuator/health", HttpMethod.GET.name())
+                        new AntPathRequestMatcher("/actuator/health", HttpMethod.GET.name()),
+                        new AntPathRequestMatcher("/**", HttpMethod.OPTIONS.name())
                 ));
 
         // 요청별 권한 관리

--- a/backend/src/main/java/com/meong9/backend/global/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/meong9/backend/global/auth/controller/AuthController.java
@@ -1,0 +1,65 @@
+package com.meong9.backend.global.auth.controller;
+
+import com.meong9.backend.domain.member.dto.LoginResponseDto;
+import com.meong9.backend.domain.member.service.KakaoService;
+import com.meong9.backend.domain.member.service.MemberService;
+import com.meong9.backend.global.auth.jwt.JwtProvider;
+import com.meong9.backend.global.dto.CommonResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.io.IOException;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class AuthController {
+    private final KakaoService kakaoService;
+    private final MemberService memberService;
+
+    /**
+     * 카카오 로그인 처리 컨트롤러
+     */
+    @GetMapping("/callback/kakao")
+    public ResponseEntity<?> kakaoLogin(@RequestParam(name = "code") String code, HttpServletResponse response) throws IOException {
+        LoginResponseDto dto = kakaoService.kakaoLogin(code, response);
+        return CommonResponse.ok("success", dto);
+    }
+
+    /**
+     * access token 재발급 요청 처리 컨트롤러
+     */
+    @PostMapping("/token")
+    public ResponseEntity<?> refreshAccessToken(@CookieValue(name = "Refresh-token") String refreshToken) {
+        String newAccessToken = memberService.refreshAccessToken(refreshToken);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(JwtProvider.AUTHORIZATION_HEADER, newAccessToken);
+
+        return ResponseEntity.ok()
+                .headers(headers)
+                .body(Map.of("message", "Access Token이 재발급되었습니다."));
+    }
+
+    /**
+     * 로그아웃 처리 컨트롤러
+     */
+    @PostMapping("/logout")
+    public ResponseEntity<?> logout(@CookieValue(name = "Refresh-token") String refreshToken,
+                                    HttpServletResponse response) {
+        memberService.logout(refreshToken);
+        Cookie cookie = new Cookie(JwtProvider.REFRESH_TOKEN_HEADER, "");
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setAttribute("SameSite", "None");
+        cookie.setMaxAge(0);
+        response.addCookie(cookie);
+        return CommonResponse.ok("success");
+    }
+}

--- a/backend/src/main/java/com/meong9/backend/global/exception/InternalServerError.java
+++ b/backend/src/main/java/com/meong9/backend/global/exception/InternalServerError.java
@@ -3,7 +3,7 @@ package com.meong9.backend.global.exception;
 import org.springframework.http.HttpStatus;
 
 public class InternalServerError extends BaseException {
-    static private final String PHOTO_PROCESSING_ERROR = "사진 처리 중 문제가 발생했습니다.";
+    static private final String PHOTO_PROCESSING_ERROR = "S3에서 사진 저장 중 문제가 발생했습니다.";
 
     public InternalServerError(String message) {
         super(HttpStatus.INTERNAL_SERVER_ERROR, message);

--- a/backend/src/main/java/com/meong9/backend/global/mediafile/service/MediaFileService.java
+++ b/backend/src/main/java/com/meong9/backend/global/mediafile/service/MediaFileService.java
@@ -234,4 +234,12 @@ public class MediaFileService {
         }
     }
 
+    public MediaFile createDefaultProfileImage() {
+        return MediaFile.builder()
+                .fileType(FileType.IMAGE)
+                .fileName("default_profile.png")
+                .fileKey("Mprofile/default_profile.png")
+                .fileUrl("https://uplus-s3-bucket-1.s3.ap-northeast-2.amazonaws.com/Mprofile/default_profile.png")
+                .build();
+    }
 }


### PR DESCRIPTION
## 📋 Summary
<!-- 이 PR에서 변경된 주요 내용을 간략히 작성해주세요. -->
- 회원가입 시 S3 오류가 생기면 기본 프로필이 지정되도록 수정
- Member Controller와 Auth Controller 분리
- Kakao Service에 @Transactional 필요한 부분에 명시적으로 지정 
- 로그인 시 멤버와 프로필 이미지를 각각 따로 조회하던 쿼리를 합치기 위해 Entity Graph 사용 
- 현재 프론트에서 오는 Options 요청을 처리하지 못해 시큐리티 설정 수정 

## ✨ Feature Details
| Method | Path                      | Description      |
|--------|---------------------------|------------------|


## 💡 Key Considerations
<!-- 구현하면서 고려한 점, 또는 해결한 주요 이슈를 간단히 작성해주세요. -->


## ✅ Checklist
- [ ] 코드를 스스로 검토했나요?
- [ ] 필요한 테스트를 추가하고 모두 통과했나요?
- [ ] 브랜치 전략에 맞는 브랜치에 PR을 올렸나요?
- [ ] 커밋 메시지가 컨벤션에 맞나요?
- [ ] 필요한 문서를 업데이트했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- 새로운 인증 관련 API 엔드포인트 추가: Kakao 로그인, 토큰 갱신, 로그아웃 기능을 포함하는 `AuthController` 클래스가 도입되었습니다.
	- 기본 프로필 이미지를 생성하는 기능이 추가되었습니다.
- **변경 사항**
	- `MemberController`의 API 엔드포인트가 `/api/v1/members`로 변경되어 URL 구조가 간소화되었습니다.
	- `nickname` 필드의 null 허용 설정이 변경되었습니다.
- **버그 수정**
	- 사진 처리 중 발생하는 오류 메시지가 S3 저장 관련 문제를 명확히 반영하도록 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->