### PR TITLE
From Kan-80-be-feat/weather into dev : 날씨 정보 저장 및 조회

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -60,6 +60,9 @@ dependencies {
 	// webflux
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
+	// redis
+	implementation("org.springframework.boot:spring-boot-starter-data-redis")
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
@@ -80,7 +83,7 @@ jooq {
 					driver = 'com.mysql.cj.jdbc.Driver'
 					url = System.getProperty('dbUrl', 'jdbc:mysql://localhost:3306/meong9')
 					user = System.getProperty('dbUsername', 'root')
-					password = System.getProperty('dbPassword', '1234')
+					password = System.getProperty('dbPassword', 'root')
 				}
 				generator {
 					database {

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -57,6 +57,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-batch'
 	implementation 'org.springframework.batch:spring-batch-core:5.1.0'
 
+	// webflux
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/backend/src/main/java/com/meong9/backend/BackendApplication.java
+++ b/backend/src/main/java/com/meong9/backend/BackendApplication.java
@@ -4,12 +4,15 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.web.config.EnableSpringDataWebSupport;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
 import static org.springframework.data.web.config.EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO;
 
 
 @SpringBootApplication
 @EnableJpaAuditing
 @EnableSpringDataWebSupport(pageSerializationMode = VIA_DTO)
+@EnableScheduling
 public class BackendApplication {
 
 	public static void main(String[] args) {

--- a/backend/src/main/java/com/meong9/backend/domain/address/repository/PlcPenAddressRepository.java
+++ b/backend/src/main/java/com/meong9/backend/domain/address/repository/PlcPenAddressRepository.java
@@ -1,12 +1,12 @@
 package com.meong9.backend.domain.address.repository;
 
 import com.meong9.backend.domain.address.entity.PlcPenAddress;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
-
-import java.util.List;
 
 import java.util.List;
 import java.util.Optional;
@@ -45,7 +45,8 @@ public interface PlcPenAddressRepository extends JpaRepository<PlcPenAddress, Lo
             WHERE ppa.address.region.regionId IN :regionIds
             AND ppa.type = :typeCode
             """)
-    List<Long> findFacilityIdsByRegionIdIn(@Param("regionIds") List<Long> regionIds, @Param("typeCode") String typeCode);
+    Page<Long> findFacilityIdsByRegionIdIn(@Param("regionIds") List<Long> regionIds, @Param("typeCode") String typeCode,
+                                           Pageable pageable);
 
     @Query("""
         SELECT pa FROM PlcPenAddress pa

--- a/backend/src/main/java/com/meong9/backend/domain/map/controller/MapController.java
+++ b/backend/src/main/java/com/meong9/backend/domain/map/controller/MapController.java
@@ -3,6 +3,7 @@ package com.meong9.backend.domain.map.controller;
 import com.meong9.backend.domain.map.dto.MapLikePointDto;
 import com.meong9.backend.domain.map.dto.MapLikeResponseDto;
 import com.meong9.backend.domain.map.dto.MapPlaceDto;
+import com.meong9.backend.domain.map.dto.MapSearchDto;
 import com.meong9.backend.domain.map.service.MapSearchService;
 import com.meong9.backend.domain.map.service.MapService;
 import com.meong9.backend.domain.member.entity.Member;
@@ -53,9 +54,9 @@ public class MapController {
             pageable = PageRequest.of(pageable.getPageNumber(), maxPageSize, pageable.getSort());
         }
 
-        Page<MapPlaceDto> mapPlaceDtoList = mapSearchService.getSearchPlcPen(member, keyword, latitude, longitude, pageable);
+        MapSearchDto dto = mapSearchService.getSearchPlcPen(member, keyword, latitude, longitude, pageable);
 
-        return CommonResponse.ok("success", mapPlaceDtoList);
+        return CommonResponse.ok("success", dto);
     }
 
     // 찜한 장소 위도, 경도 조회 (마커용)
@@ -65,6 +66,7 @@ public class MapController {
 
         return CommonResponse.ok("success", mapPointList);
     }
+
     // 장소 조회
     @GetMapping("/places")
     public ResponseEntity<?> getSelectPlcPen(@CurrentMember Member member,

--- a/backend/src/main/java/com/meong9/backend/domain/map/dto/MapSearchDto.java
+++ b/backend/src/main/java/com/meong9/backend/domain/map/dto/MapSearchDto.java
@@ -1,0 +1,16 @@
+package com.meong9.backend.domain.map.dto;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class MapSearchDto {
+    private final List<MapPlaceDto> content;
+    private final boolean hasNext;
+
+    public MapSearchDto(List<MapPlaceDto> content, boolean hasNext) {
+        this.content = content;
+        this.hasNext = hasNext;
+    }
+}

--- a/backend/src/main/java/com/meong9/backend/domain/map/service/MapSearchService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/map/service/MapSearchService.java
@@ -4,6 +4,7 @@ import com.meong9.backend.domain.address.entity.PlcPenAddress;
 import com.meong9.backend.domain.address.repository.PlcPenAddressRepository;
 import com.meong9.backend.domain.like.repository.LikeRepository;
 import com.meong9.backend.domain.map.dto.MapPlaceDto;
+import com.meong9.backend.domain.map.dto.MapSearchDto;
 import com.meong9.backend.domain.member.entity.Member;
 import com.meong9.backend.domain.pension.entity.Pension;
 import com.meong9.backend.domain.pension.repository.PensionRepository;
@@ -15,11 +16,8 @@ import com.meong9.backend.global.utils.AddressMapper;
 import com.meong9.backend.global.utils.DistanceMapper;
 import com.meong9.backend.global.utils.TypeCodeMapper;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -50,18 +48,18 @@ public class MapSearchService {
 
     // 장소 검색
     @Transactional(readOnly = true)
-    public Page<MapPlaceDto> getSearchPlcPen(Member member, String searchWord, Double userLatitude, Double userLongitude, Pageable pageable) {
+    public MapSearchDto getSearchPlcPen(Member member, String searchWord, Double userLatitude, Double userLongitude, Pageable pageable) {
         // 검색어로 조회
-        List<Long> placeIds = searchJooqRepository.findPlaceIdsBySearchWord(searchWord);
-        List<Long> pensionIds = searchJooqRepository.findPensionIdsBySearchWord(searchWord);
+        Slice<Long> placeIds = searchJooqRepository.findPlaceIdsBySearchWord(searchWord, pageable);
+        Slice<Long> pensionIds = searchJooqRepository.findPensionIdsBySearchWord(searchWord, pageable);
 
         // Place와 Pension ID로 조회
-        List<Object[]> places = placeRepository.findAllWithLikeStatus(placeIds, member);  // List로 Place 조회
-        List<Object[]> pensions = pensionRepository.findAllWithLikeStatus(pensionIds, member);  // List로 Pension 조회
+        List<Object[]> places = placeRepository.findAllWithLikeStatus(placeIds.getContent(), member);  // List로 Place 조회
+        List<Object[]> pensions = pensionRepository.findAllWithLikeStatus(pensionIds.getContent(), member);  // List로 Pension 조회
 
         // PlcPenAddress에서 주소 가져오기
-        List<PlcPenAddress> pensionAddresses = plcPenAddressRepository.findAddressesByIdsAndType(pensionIds, "020");
-        List<PlcPenAddress> placeAddresses = plcPenAddressRepository.findAddressesByIdsAndType(placeIds, "010");
+        List<PlcPenAddress> pensionAddresses = plcPenAddressRepository.findAddressesByIdsAndType(pensionIds.getContent(), "020");
+        List<PlcPenAddress> placeAddresses = plcPenAddressRepository.findAddressesByIdsAndType(placeIds.getContent(), "010");
 
         // 주소 매핑
         Map<Long, String> pensionAddressMap = AddressMapper.mapAddressesByPlcPenId(pensionAddresses);
@@ -137,21 +135,10 @@ public class MapSearchService {
             allResults.add(mapPlaceDto);
         }
 
-        // 거리 정렬
-        List<MapPlaceDto> sortedResults = sortByDistance(allResults);
+        boolean hasNext = placeIds.hasNext() || pensionIds.hasNext();
 
-        // 페이지 처리
-        int start = (int) pageable.getOffset();
-        if (start >= sortedResults.size()) {
-            return new PageImpl<>(Collections.emptyList(), pageable, sortedResults.size());
-        }
-        int end = Math.min(start + pageable.getPageSize(), sortedResults.size());
-
-        // 페이지 처리된 결과 생성
-        List<MapPlaceDto> pageContent = sortedResults.subList(start, end);
-
-        // PageImpl 생성하여 반환
-        return new PageImpl<>(pageContent, pageable, sortedResults.size());
+        // 거리 정렬 후 반환
+        return new MapSearchDto(sortByDistance(allResults), hasNext);
     }
 
 

--- a/backend/src/main/java/com/meong9/backend/domain/search/repository/SearchJooqRepository.java
+++ b/backend/src/main/java/com/meong9/backend/domain/search/repository/SearchJooqRepository.java
@@ -8,10 +8,10 @@ import org.springframework.data.domain.Slice;
 import java.util.List;
 
 public interface SearchJooqRepository {
-    Slice<SearchPlaceDto> searchPlaces(List<Long> regionIds, List<Long> categoryIds, String sizeCode, String typeCode, Pageable pageable, Long memberId);
-    Slice<SearchPensionDto> searchPensions(List<Long> filteredPensionIds, String startDate, String endDate, String sizeCode, String typeCode, Pageable pageable, Long memberId);
+    List<SearchPlaceDto> searchPlaces(List<Long> regionIds, List<Long> categoryIds, String sizeCode, String typeCode, Long memberId);
+    List<SearchPensionDto> searchPensions(List<Long> filteredPensionIds, String startDate, String endDate, String sizeCode, String typeCode, Long memberId);
 
-    List<Long> findPlaceIdsBySearchWord(String searchWord);
-    List<Long> findPensionIdsBySearchWord(String searchWord);
+    Slice<Long> findPlaceIdsBySearchWord(String searchWord, Pageable pageable);
+    Slice<Long> findPensionIdsBySearchWord(String searchWord, Pageable pageable);
 
 }

--- a/backend/src/main/java/com/meong9/backend/domain/search/repository/SearchJooqRepositoryImpl.java
+++ b/backend/src/main/java/com/meong9/backend/domain/search/repository/SearchJooqRepositoryImpl.java
@@ -15,9 +15,9 @@ import org.springframework.stereotype.Repository;
 import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import static com.meong9.backend.jooq.generated.Tables.*;
-
 
 @Repository
 @RequiredArgsConstructor
@@ -26,20 +26,18 @@ public class SearchJooqRepositoryImpl implements SearchJooqRepository {
     private final DSLContext dsl;
 
     @Override
-    public Slice<SearchPlaceDto> searchPlaces(List<Long> filteredPlaceIds, List<Long> categoryIds, String sizeCode, String typeCode, Pageable pageable, Long memberId) {
-        int offset = (int) pageable.getOffset();
-        int pageSize = pageable.getPageSize();
+    public List<SearchPlaceDto> searchPlaces(List<Long> filteredPlaceIds, List<Long> categoryIds, String sizeCode, String typeCode, Long memberId) {
 
         List<SearchPlaceDto> places = dsl.select(
                         PLACE.PLACE_ID, // placeId
                         PLACE.PLACE_NAME.as("placeName"), // placeName
-                        getAddressField(typeCode).as("address"), // address
+                        getAddressFieldForPlace(typeCode).as("address"), // address
                         PLC_CATEGORY.PLC_CATEGORY_NAME.as("placeType"), // placeType
                         PLACE.REVIEW_AVG, // reviewAverage
                         PLACE.REVIEW_COUNT, // reviewCount
                         PLACE.ENTER_PET_SIZE.as("weightLimit"), // weightLimit
                         PLACE.BUSINESS_HOUR, // businessHour
-                        getLikeStatusField(memberId) // boolean likeStatus
+                        getLikeStatusFieldForPlace(memberId) // boolean likeStatus
                 )
                 .from(PLACE)
                 .join(PLC_CATEGORY).on(PLACE.PLC_CATEGORY_ID.eq(PLC_CATEGORY.PLC_CATEGORY_ID))
@@ -48,29 +46,37 @@ public class SearchJooqRepositoryImpl implements SearchJooqRepository {
                                 .and(PLACE.PLC_CATEGORY_ID.in(categoryIds))
                                 .and(getWeightCondition(sizeCode))
                 )
-                .limit(pageSize)
-                .offset(offset)
+                .orderBy(DSL.field("review_count").desc())
                 .fetchInto(SearchPlaceDto.class);
 
+        // filteredPlaceIds에 해당하는 태그 & 이미지 데이터를 한 번에 조회
+        Map<Long, List<String>> tagsByPlaceId = dsl.select(PLACE_TAG.PLACE_ID, TAG.TAG_NAME)
+                .from(PLACE_TAG)
+                .join(TAG).on(PLACE_TAG.TAG_ID.eq(TAG.TAG_ID))
+                .where(PLACE_TAG.PLACE_ID.in(filteredPlaceIds))
+                .fetchGroups(PLACE_TAG.PLACE_ID, TAG.TAG_NAME);
+
+        Map<Long, List<String>> imagesByPlaceId = dsl.select(PLACE_FILE.PLACE_ID, MEDIA_FILE.FILE_URL)
+                .from(PLACE_FILE)
+                .join(MEDIA_FILE).on(PLACE_FILE.MEDIA_FILE_ID.eq(MEDIA_FILE.MEDIA_FILE_ID))
+                .where(PLACE_FILE.PLACE_ID.in(filteredPlaceIds))
+                .fetchGroups(PLACE_FILE.PLACE_ID, MEDIA_FILE.FILE_URL);
+
+        // 태그 & 이미지 데이터 매핑
         places.forEach(place -> {
-            List<String> tags = getTags(place.getPlaceId()); // 태그 조회
+            List<String> tags = tagsByPlaceId.getOrDefault(place.getPlaceId(), List.of());
             place.setTags(tags);
 
-            List<String> images = getImages(place.getPlaceId()); // 이미지 조회
+            List<String> images = imagesByPlaceId.getOrDefault(place.getPlaceId(), List.of());
             place.setImages(images);
         });
 
-        boolean hasNext = places.size() == pageSize;
-
-        return new SliceImpl<>(places, pageable, hasNext);
+        return places;
     }
 
     @Override
-    public Slice<SearchPensionDto> searchPensions(List<Long> filteredPensionIds, String startDate, String endDate, String sizeCode, String typeCode, Pageable pageable, Long memberId) {
-        int offset = (int) pageable.getOffset();
-        int pageSize = pageable.getPageSize();
+    public List<SearchPensionDto> searchPensions(List<Long> filteredPensionIds, String startDate, String endDate, String sizeCode, String typeCode,  Long memberId) {
 
-        // jOOQ 쿼리
         List<SearchPensionDto> pensions = dsl.select(
                         PENSION.PENSION_ID.as("pensionId"),
                         PENSION.PENSION_NAME.as("pensionName"),
@@ -116,60 +122,75 @@ public class SearchJooqRepositoryImpl implements SearchJooqRepository {
                         PENSION.END_TIME
                 )
                 .orderBy(DSL.field("isAvailable").desc(), PENSION.REVIEW_COUNT.desc()) // 예약 가능 여부 > 리뷰 평균 기준 정렬
-                .limit(pageSize)
-                .offset(offset)
                 .fetchInto(SearchPensionDto.class); // DTO로 매핑
 
+        // filteredPlaceIds에 해당하는 태그 & 이미지 데이터를 한 번에 조회
+        Map<Long, List<String>> tagsByPensionId = dsl.select(PENSION_TAG.PENSION_ID, TAG.TAG_NAME)
+                .from(PENSION_TAG)
+                .join(TAG).on(PENSION_TAG.TAG_ID.eq(TAG.TAG_ID))
+                .where(PENSION_TAG.PENSION_ID.in(filteredPensionIds))
+                .fetchGroups(PENSION_TAG.PENSION_ID, TAG.TAG_NAME);
+
+        Map<Long, List<String>> imagesByPensionId = dsl.select(PENSION_FILE.PENSION_ID, MEDIA_FILE.FILE_URL)
+                .from(PENSION_FILE)
+                .join(MEDIA_FILE).on(PENSION_FILE.MEDIA_FILE_ID.eq(MEDIA_FILE.MEDIA_FILE_ID))
+                .where(PENSION_FILE.PENSION_ID.in(filteredPensionIds))
+                .fetchGroups(PENSION_FILE.PENSION_ID, MEDIA_FILE.FILE_URL);
+
+        // 태그 & 이미지 데이터 매핑
         pensions.forEach(pension -> {
-            List<String> tags = getTagsForPension(pension.getPensionId()); // 태그 조회
+            List<String> tags = tagsByPensionId.getOrDefault(pension.getPensionId(), List.of());
             pension.setTags(tags);
 
-            List<String> images = getImagesForPension(pension.getPensionId()); // 이미지 조회
+            List<String> images = imagesByPensionId.getOrDefault(pension.getPensionId(), List.of());
             pension.setImages(images);
         });
 
-        boolean hasNext = pensions.size() == pageSize;
-
-        return new SliceImpl<>(pensions, pageable, hasNext);
+        return pensions;
     }
 
     @Override
-    public List<Long> findPlaceIdsBySearchWord(String searchWord) {
+    public Slice<Long> findPlaceIdsBySearchWord(String searchWord, Pageable pageable) {
         // 검색어를 단어별로 나누어 배열에 담기
         String[] searchWords = searchWord.split(" ");
 
-        return dsl
-                .selectDistinct(DSL.field("p.place_id", Long.class))
-                .from(
-                        dsl.select(PLACE.PLACE_ID)
-                                .from(PLACE)
-                                .where(
-                                        Arrays.stream(searchWords)
-                                                .map(word -> DSL.condition(
-                                                        "MATCH(place_name, plc_description) AGAINST (? IN BOOLEAN MODE)", word + "*"
-                                                ))
-                                                .reduce(DSL.noCondition(), DSL::or)
-                                )
-                                .asTable("p")
-                )
-                .join(PLC_PEN_ADDRESS).on(DSL.field("p.place_id").eq(PLC_PEN_ADDRESS.PLC_PEN_ID))
-                .join(
-                        dsl.select(ADDRESS.ADDRESS_ID)
-                                .from(ADDRESS)
-                                .where(
-                                        Arrays.stream(searchWords)
-                                                .map(word -> DSL.condition(
-                                                        "MATCH(address, province, city_district, subdistrict) AGAINST (? IN BOOLEAN MODE)", word + "*"
-                                                ))
-                                                .reduce(DSL.noCondition(), DSL::or)
-                                )
-                                .asTable("a")
-                ).on(PLC_PEN_ADDRESS.ADDRESS_ID.eq(DSL.field("a.address_id", Long.class)))
+        // place 테이블에서 검색
+        var placeQuery = dsl.select(PLACE.PLACE_ID)
+                .from(PLACE)
+                .where(
+                        Arrays.stream(searchWords)
+                                .map(word -> DSL.condition(
+                                        "MATCH(place_name, plc_description) AGAINST (? IN BOOLEAN MODE)", word + "*"
+                                ))
+                                .reduce(DSL.noCondition(), DSL::or)
+                );
+
+        // address 테이블에서 검색
+        var addressQuery = dsl.select(PLC_PEN_ADDRESS.PLC_PEN_ID)
+                .from(ADDRESS)
+                .join(PLC_PEN_ADDRESS).on(PLC_PEN_ADDRESS.ADDRESS_ID.eq(ADDRESS.ADDRESS_ID))
+                .where(
+                        Arrays.stream(searchWords)
+                                .map(word -> DSL.condition(
+                                        "MATCH(address, province, city_district, subdistrict) AGAINST (? IN BOOLEAN MODE)", word + "*"
+                                ))
+                                .reduce(DSL.noCondition(), DSL::or)
+                );
+
+        // 두 결과를 UNION으로 합치기
+        List<Long> result =  dsl.selectDistinct(DSL.field("place_id", Long.class))
+                .from(placeQuery.union(addressQuery).asTable("combined_results"))
+                .limit(pageable.getPageSize())
+                .offset((int) pageable.getOffset())
                 .fetchInto(Long.class);
+
+        boolean hasNext = result.size() > pageable.getPageSize();
+
+        return new SliceImpl<>(result, pageable, hasNext);
     }
 
     @Override
-    public List<Long> findPensionIdsBySearchWord(String searchWord) {
+    public Slice<Long> findPensionIdsBySearchWord(String searchWord, Pageable pageable) {
         // 검색어를 단어별로 나누어 배열에 담기
         String[] searchWords = searchWord.split(" ");
 
@@ -194,14 +215,20 @@ public class SearchJooqRepositoryImpl implements SearchJooqRepository {
                                 .reduce(DSL.noCondition(), DSL::or)
                 );
 
-        // union으로 합치기 (or과 비교해 볼 필요 있음)
-        return dsl.selectDistinct(DSL.field("pension_id", Long.class))
+        // 두 결과를 UNION으로 합치기
+        List<Long> result =  dsl.selectDistinct(DSL.field("pension_id", Long.class))
                 .from(pensionQuery.union(addressQuery).asTable("combined_results"))
+                .limit(pageable.getPageSize())
+                .offset((int) pageable.getOffset())
                 .fetchInto(Long.class);
+
+        boolean hasNext = result.size() > pageable.getPageSize();
+
+        return new SliceImpl<>(result, pageable, hasNext);
     }
 
 
-    private Field<String> getAddressField(String typeCode) {
+    private Field<String> getAddressFieldForPlace(String typeCode) {
         return dsl.select(ADDRESS.ADDRESS_)
                 .from(PLC_PEN_ADDRESS)
                 .join(ADDRESS).on(PLC_PEN_ADDRESS.ADDRESS_ID.eq(ADDRESS.ADDRESS_ID))
@@ -219,39 +246,7 @@ public class SearchJooqRepositoryImpl implements SearchJooqRepository {
                 .asField();
     }
 
-    private List<String> getTags(Long placeId) {
-        return dsl.select(TAG.TAG_NAME)
-                .from(PLACE_TAG)
-                .join(TAG).on(PLACE_TAG.TAG_ID.eq(TAG.TAG_ID))
-                .where(PLACE_TAG.PLACE_ID.eq(placeId))
-                .fetchInto(String.class);
-    }
-
-    private List<String> getTagsForPension(Long pensionId) {
-        return dsl.select(TAG.TAG_NAME)
-                .from(PENSION_TAG)
-                .join(TAG).on(PENSION_TAG.TAG_ID.eq(TAG.TAG_ID))
-                .where(PENSION_TAG.PENSION_ID.eq(pensionId))
-                .fetchInto(String.class);
-    }
-
-    private List<String> getImages(Long placeId) {
-        return dsl.select(MEDIA_FILE.FILE_URL)
-                .from(PLACE_FILE)
-                .join(MEDIA_FILE).on(PLACE_FILE.MEDIA_FILE_ID.eq(MEDIA_FILE.MEDIA_FILE_ID))
-                .where(PLACE_FILE.PLACE_ID.eq(placeId))
-                .fetchInto(String.class);
-    }
-
-    private List<String> getImagesForPension(Long pensionId) {
-        return dsl.select(MEDIA_FILE.FILE_URL)
-                .from(PENSION_FILE)
-                .join(MEDIA_FILE).on(PENSION_FILE.MEDIA_FILE_ID.eq(MEDIA_FILE.MEDIA_FILE_ID))
-                .where(PENSION_FILE.PENSION_ID.eq(pensionId))
-                .fetchInto(String.class);
-    }
-
-    private Field<Boolean> getLikeStatusField(Long memberId) {
+    private Field<Boolean> getLikeStatusFieldForPlace(Long memberId) {
         if (memberId == null) {
             return DSL.inline(false).as("likeStatus");
         }
@@ -294,3 +289,4 @@ public class SearchJooqRepositoryImpl implements SearchJooqRepository {
     }
 
 }
+

--- a/backend/src/main/java/com/meong9/backend/domain/search/service/SearchService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/search/service/SearchService.java
@@ -8,16 +8,15 @@ import com.meong9.backend.domain.puppy.repository.PuppyRepository;
 import com.meong9.backend.domain.search.dto.*;
 import com.meong9.backend.domain.search.repository.SearchJooqRepository;
 import com.meong9.backend.global.repository.RegionRepository;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 @Service
-@Transactional
 @RequiredArgsConstructor
 public class SearchService {
     private final PuppyRepository puppyRepository;
@@ -29,6 +28,7 @@ public class SearchService {
     /**
      * 멤버의 모든 강아지를 puppyId 기준으로 정렬하여 조회하는 서비스 메서드
      */
+    @Transactional(readOnly = true)
     public PuppiesForSearchDto getPuppiesForSearch(Member member) {
         List<Puppy> puppies = puppyRepository.findByMemberIdWithPuppyProfileImage(member.getMemberId());
         List<PuppiesWithWeightDto> puppiesWithWeightDto = puppies.stream()
@@ -45,22 +45,23 @@ public class SearchService {
     /**
      * 1) 지역, 2) 장소 카테고리, 3) 강아지 무게 를 기반으로 필터링하여 장소를 검색하는 서비스 메서드
      */
+    @Transactional(readOnly = true)
     public SearchPlacesResponseDto searchPlaces(String searchWord, List<String> regionList, List<String> placeTypes,
                                                 double heaviestDogWeight, Pageable pageable, Long memberId) {
         String typeCode = "010"; // 시설 코드
 
-        List<Long> filteredPlaceIds; // 최종 필터링된 시설 ID 목록
+        Slice<Long> filteredPlaceIds; // 최종 필터링된 시설 ID 목록
 
         if (searchWord != null && !searchWord.trim().isEmpty()) {
             // 1. 검색어로 시설 ID 필터링
-            filteredPlaceIds = searchRepository.findPlaceIdsBySearchWord(searchWord);
+            filteredPlaceIds = searchRepository.findPlaceIdsBySearchWord(searchWord, pageable);
         } else {
             // 2. 지역으로 시설 ID 필터링
             List<Long> regionIds = (regionList == null || regionList.isEmpty())
                     ? regionRepository.findAllRegionIds()
                     : regionRepository.findRegionIdsByNameIn(regionList);
 
-            filteredPlaceIds = plcPenAddressRepository.findFacilityIdsByRegionIdIn(regionIds, typeCode);
+            filteredPlaceIds = plcPenAddressRepository.findFacilityIdsByRegionIdIn(regionIds, typeCode, pageable);
         }
 
         List<Long> categoryIds = (placeTypes == null || placeTypes.isEmpty())
@@ -71,53 +72,52 @@ public class SearchService {
         String sizeCode = heaviestDogWeight < 10 ? "010" : heaviestDogWeight < 25 ? "020" : "030";
 
         // 3. 최종 필터링된 시설 조회
-        Slice<SearchPlaceDto> filteredPlaces =
+        List<SearchPlaceDto> filteredPlaces =
                 searchRepository.searchPlaces(
-                filteredPlaceIds,
+                filteredPlaceIds.getContent(),
                 categoryIds,
                 sizeCode,
                 typeCode,
-                pageable,
                 memberId);
 
         // 4. 반환
-        return new SearchPlacesResponseDto(filteredPlaces.getContent(), filteredPlaces.hasNext());
+        return new SearchPlacesResponseDto(filteredPlaces, filteredPlaceIds.hasNext());
     }
 
+    @Transactional(readOnly = true)
     public SearchPensionsResponseDto searchPensions(String searchWord, List<String> regionList,
                                                     double heaviestDogWeight, String startDate, String endDate,
                                                     Pageable pageable, Long memberId) {
         String typeCode = "020"; // 펜션 코드
 
-        List<Long> filteredPensionIds; // 최종 필터링된 펜션 ID 목록
+        Slice<Long> filteredPensionIds; // 최종 필터링된 펜션 ID 목록
 
         if (searchWord != null && !searchWord.trim().isEmpty()) {
             // 1. 검색어로 펜션 ID 필터링
-            filteredPensionIds = searchRepository.findPensionIdsBySearchWord(searchWord);
+            filteredPensionIds = searchRepository.findPensionIdsBySearchWord(searchWord, pageable);
         } else {
             // 2. 지역으로 펜션 ID 필터링
             List<Long> regionIds = (regionList == null || regionList.isEmpty())
                     ? regionRepository.findAllRegionIds()
                     : regionRepository.findRegionIdsByNameIn(regionList);
 
-            filteredPensionIds = plcPenAddressRepository.findFacilityIdsByRegionIdIn(regionIds, typeCode);
+            filteredPensionIds = plcPenAddressRepository.findFacilityIdsByRegionIdIn(regionIds, typeCode, pageable);
         }
 
         // 2. 반려견 체중 조건 추가
         String sizeCode = heaviestDogWeight < 10 ? "010" : heaviestDogWeight < 25 ? "020" : "030";
 
         // 3. 최종 필터링된 시설 조회
-        Slice<SearchPensionDto> filteredPensions =
+        List<SearchPensionDto> filteredPensions =
                 searchRepository.searchPensions(
-                        filteredPensionIds,
+                        filteredPensionIds.getContent(),
                         startDate,
                         endDate,
                         sizeCode,
                         typeCode,
-                        pageable,
                         memberId);
 
         // 4. 반환
-        return new SearchPensionsResponseDto(filteredPensions.getContent(), filteredPensions.hasNext());
+        return new SearchPensionsResponseDto(filteredPensions, filteredPensionIds.hasNext());
     }
 }

--- a/backend/src/main/java/com/meong9/backend/domain/weather/controller/WeatherController.java
+++ b/backend/src/main/java/com/meong9/backend/domain/weather/controller/WeatherController.java
@@ -1,23 +1,33 @@
 package com.meong9.backend.domain.weather.controller;
 
+import com.meong9.backend.domain.weather.dto.WeatherDto;
+import com.meong9.backend.domain.weather.service.WeatherApiService;
 import com.meong9.backend.domain.weather.service.WeatherService;
+import com.meong9.backend.global.dto.CommonResponse;
+import com.meong9.backend.global.exception.BadRequestException;
+import com.meong9.backend.global.utils.RegionMapper;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/v1")
 public class WeatherController {
 
     private final WeatherService weatherService;
 
     @GetMapping("/weather")
-    public String getWeather() {
-        return weatherService.getWeatherForecast();
-    }
+    public ResponseEntity<?> getWeather(@RequestParam(name = "region") String region){
+        String regionName = RegionMapper.getWeatherRegion(region); // 지역 코드
+        if(regionName == null){
+            throw BadRequestException.invalidRegionNameFormat(region);
+        }
+        WeatherDto weatherDto = weatherService.getWeatherData(region);
 
-    @GetMapping("/weather/2")
-    public String getWeather2() {
-        return weatherService.getWeatherForecast2();
+        return CommonResponse.ok("success", weatherDto);
     }
 }

--- a/backend/src/main/java/com/meong9/backend/domain/weather/controller/WeatherController.java
+++ b/backend/src/main/java/com/meong9/backend/domain/weather/controller/WeatherController.java
@@ -15,4 +15,9 @@ public class WeatherController {
     public String getWeather() {
         return weatherService.getWeatherForecast();
     }
+
+    @GetMapping("/weather/2")
+    public String getWeather2() {
+        return weatherService.getWeatherForecast2();
+    }
 }

--- a/backend/src/main/java/com/meong9/backend/domain/weather/controller/WeatherController.java
+++ b/backend/src/main/java/com/meong9/backend/domain/weather/controller/WeatherController.java
@@ -1,0 +1,18 @@
+package com.meong9.backend.domain.weather.controller;
+
+import com.meong9.backend.domain.weather.service.WeatherService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class WeatherController {
+
+    private final WeatherService weatherService;
+
+    @GetMapping("/weather")
+    public String getWeather() {
+        return weatherService.getWeatherForecast();
+    }
+}

--- a/backend/src/main/java/com/meong9/backend/domain/weather/dto/WeatherDto.java
+++ b/backend/src/main/java/com/meong9/backend/domain/weather/dto/WeatherDto.java
@@ -1,0 +1,23 @@
+package com.meong9.backend.domain.weather.dto;
+
+import lombok.*;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+public class WeatherDto {
+    @Setter
+    private String regionName;
+
+    private String day1;
+    private String day2;
+    private String day3;
+    private String day4;
+    private String day5;
+    private String day6;
+    private String day7;
+    private String day8;
+    private String day9;
+    private String day10;
+}

--- a/backend/src/main/java/com/meong9/backend/domain/weather/service/WeatherApiService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/weather/service/WeatherApiService.java
@@ -19,8 +19,6 @@ import java.net.URLEncoder;
 @RequiredArgsConstructor
 public class WeatherApiService {
 
-    private final WebClient webClient;
-
     @Value("${weather.mid.encoding-key}")
     private String weatherMidKey; // 중기 예보 키
 
@@ -71,7 +69,7 @@ public class WeatherApiService {
 
             return responseBody;
         } catch (IOException e) {
-            throw new RuntimeException("데이터를 읽어오는 데 오류 발생", e);
+            throw InternalServerError.weatherApiError("데이터를 읽어오는 데 오류 발생: " + e);
         }
     }
 

--- a/backend/src/main/java/com/meong9/backend/domain/weather/service/WeatherApiService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/weather/service/WeatherApiService.java
@@ -41,8 +41,6 @@ public class WeatherApiService {
             conn.setRequestMethod("GET");
             conn.setRequestProperty("Content-type", "application/json");
 
-            System.out.println("Request URL: " + urlBuilder.toString());
-
             // 응답 코드 확인
             int responseCode = conn.getResponseCode();
             System.out.println("Response code: " + responseCode);

--- a/backend/src/main/java/com/meong9/backend/domain/weather/service/WeatherApiService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/weather/service/WeatherApiService.java
@@ -17,8 +17,8 @@ public class WeatherApiService {
 
     private final WebClient webClient;
 
-    @Value("${weather.mid.encoding-key}")
-    private String weatherMidKey; // 중기 예보 키
+    @Value("${weather.encoding-key}")
+    private String weatherKey; // 서비스 키
 
     // 단기 예보
     public String getWeatherForecastST(String[] xy, String date) {
@@ -26,7 +26,7 @@ public class WeatherApiService {
             // URL 포맷 지정
             String url = String.format(
                     "http://apis.data.go.kr/1360000/VilageFcstInfoService_2.0/getVilageFcst?serviceKey=%s&pageNo=1&numOfRows=798&dataType=JSON&base_date=%s&base_time=1400&nx=%s&ny=%s",
-                    weatherMidKey, date, xy[0], xy[1]
+                    weatherKey, date, xy[0], xy[1]
             );
 
             // WebClient 호출
@@ -53,7 +53,7 @@ public class WeatherApiService {
             // URL 포맷 지정
             String url = String.format(
                     "http://apis.data.go.kr/1360000/MidFcstInfoService/getMidLandFcst?serviceKey=%s&pageNo=1&numOfRows=10&dataType=JSON&regId=%s&tmFc=%s",
-                    weatherMidKey, code, date
+                    weatherKey, code, date
             );
 
             // WebClient 호출

--- a/backend/src/main/java/com/meong9/backend/domain/weather/service/WeatherApiService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/weather/service/WeatherApiService.java
@@ -1,130 +1,76 @@
 package com.meong9.backend.domain.weather.service;
 
+import com.meong9.backend.global.exception.BadRequestException;
 import com.meong9.backend.global.exception.InternalServerError;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 
-import java.io.IOException;
+import java.net.URI;
 
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.net.URLEncoder;
 
 
 @Service
 @RequiredArgsConstructor
 public class WeatherApiService {
 
+    private final WebClient webClient;
+
     @Value("${weather.mid.encoding-key}")
     private String weatherMidKey; // 중기 예보 키
-
-    public String getWeatherForecastMid(String code, String date) {
-        try {
-            // URL 빌드
-            StringBuilder urlBuilder = new StringBuilder("http://apis.data.go.kr/1360000/MidFcstInfoService/getMidLandFcst");
-            urlBuilder.append("?").append("serviceKey").append("=").append(weatherMidKey);
-            urlBuilder.append("&").append(URLEncoder.encode("pageNo", "UTF-8")).append("=").append(URLEncoder.encode("1", "UTF-8"));
-            urlBuilder.append("&").append(URLEncoder.encode("numOfRows", "UTF-8")).append("=").append(URLEncoder.encode("10", "UTF-8"));
-            urlBuilder.append("&").append(URLEncoder.encode("dataType", "UTF-8")).append("=").append(URLEncoder.encode("JSON", "UTF-8"));
-            urlBuilder.append("&").append(URLEncoder.encode("regId", "UTF-8")).append("=").append(URLEncoder.encode(code, "UTF-8"));
-            urlBuilder.append("&").append(URLEncoder.encode("tmFc", "UTF-8")).append("=").append(URLEncoder.encode(date, "UTF-8"));
-
-            // URL 객체 생성
-            URL url = new URL(urlBuilder.toString());
-            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-            conn.setRequestMethod("GET");
-            conn.setRequestProperty("Content-type", "application/json");
-
-            // 응답 코드 확인
-            int responseCode = conn.getResponseCode();
-            System.out.println("Response code: " + responseCode);
-
-            // 응답 처리
-            BufferedReader rd;
-            if (responseCode >= 200 && responseCode <= 300) {
-                rd = new BufferedReader(new InputStreamReader(conn.getInputStream()));
-            } else {
-                rd = new BufferedReader(new InputStreamReader(conn.getErrorStream()));
-            }
-
-            // 응답 데이터를 읽어 들이기
-            StringBuilder response = new StringBuilder();
-            String line;
-            while ((line = rd.readLine()) != null) {
-                response.append(line);
-            }
-            rd.close();
-            conn.disconnect();
-
-            // JSON 형식인지 확인
-            String responseBody = response.toString().trim();
-            if (!responseBody.startsWith("{") && !responseBody.startsWith("[")) {
-                System.out.println("Received non-JSON response: " + responseBody);
-                throw InternalServerError.weatherApiError("Invalid response format: " + responseBody);
-            }
-
-            return responseBody;
-        } catch (IOException e) {
-            throw InternalServerError.weatherApiError("데이터를 읽어오는 데 오류 발생: " + e);
-        }
-    }
 
     // 단기 예보
     public String getWeatherForecastST(String[] xy, String date) {
         try {
-            // URL 빌드
-            StringBuilder urlBuilder = new StringBuilder("http://apis.data.go.kr/1360000/VilageFcstInfoService_2.0/getVilageFcst");
-            urlBuilder.append("?").append("serviceKey").append("=").append(weatherMidKey);
-            urlBuilder.append("&").append(URLEncoder.encode("pageNo", "UTF-8")).append("=").append(URLEncoder.encode("1", "UTF-8")); // 페이지 번호
-            urlBuilder.append("&").append(URLEncoder.encode("numOfRows", "UTF-8")).append("=").append(URLEncoder.encode("798", "UTF-8")); // 한 페이지 결과 수
-            urlBuilder.append("&").append(URLEncoder.encode("dataType", "UTF-8")).append("=").append(URLEncoder.encode("JSON", "UTF-8")); // 데이터 형식
-            urlBuilder.append("&").append(URLEncoder.encode("base_date", "UTF-8")).append("=").append(URLEncoder.encode(date, "UTF-8")); // 발표 날짜
-            urlBuilder.append("&").append(URLEncoder.encode("base_time", "UTF-8")).append("=").append(URLEncoder.encode("1400", "UTF-8")); // 발표 시간
-            urlBuilder.append("&").append(URLEncoder.encode("nx", "UTF-8")).append("=").append(URLEncoder.encode(xy[0], "UTF-8")); // 예보 지점 X 좌표 값
-            urlBuilder.append("&").append(URLEncoder.encode("ny", "UTF-8")).append("=").append(URLEncoder.encode(xy[1], "UTF-8")); // 예보 지점 Y 좌표 값
+            // URL 포맷 지정
+            String url = String.format(
+                    "http://apis.data.go.kr/1360000/VilageFcstInfoService_2.0/getVilageFcst?serviceKey=%s&pageNo=1&numOfRows=798&dataType=JSON&base_date=%s&base_time=1400&nx=%s&ny=%s",
+                    weatherMidKey, date, xy[0], xy[1]
+            );
 
-            // URL 객체 생성
-            URL url = new URL(urlBuilder.toString());
-            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-            conn.setRequestMethod("GET");
-            conn.setRequestProperty("Content-type", "application/json");
+            // WebClient 호출
+            String responseBody = webClient.get()
+                    .uri(URI.create(url)) // 자동 인코딩 방지
+                    .retrieve()
+                    .bodyToMono(String.class)
+                    .block();
 
-            System.out.println("Request URL: " + urlBuilder.toString());
-
-            // 응답 코드 확인
-            int responseCode = conn.getResponseCode();
-            System.out.println("Response code: " + responseCode);
-
-            // 응답 처리
-            BufferedReader rd;
-            if (responseCode >= 200 && responseCode <= 300) {
-                rd = new BufferedReader(new InputStreamReader(conn.getInputStream()));
-            } else {
-                rd = new BufferedReader(new InputStreamReader(conn.getErrorStream()));
-            }
-
-            StringBuilder response = new StringBuilder();
-            String line;
-            while ((line = rd.readLine()) != null) {
-                response.append(line);
-            }
-            rd.close();
-            conn.disconnect();
-
-            // JSON 형식인지 확인
-            String responseBody = response.toString().trim();
-            if (!responseBody.startsWith("{") && !responseBody.startsWith("[")) {
-                System.out.println("Received non-JSON response: " + responseBody);
-                throw InternalServerError.weatherApiError("Invalid response format: " + responseBody);
+            // JSON 형식 검증
+            if (!responseBody.trim().startsWith("{") && !responseBody.trim().startsWith("[")) {
+                throw InternalServerError.invalidWeatherResponseFormat(responseBody);
             }
 
             return responseBody;
-        } catch (IOException e) {
-            throw new RuntimeException("데이터를 읽어오는 데 오류 발생", e);
+        } catch (Exception e) {
+            throw InternalServerError.weatherApiError(e.getMessage());
+        }
+    }
+
+    // 중기 예보
+    public String getWeatherForecastMid(String code, String date) {
+        try {
+            // URL 포맷 지정
+            String url = String.format(
+                    "http://apis.data.go.kr/1360000/MidFcstInfoService/getMidLandFcst?serviceKey=%s&pageNo=1&numOfRows=10&dataType=JSON&regId=%s&tmFc=%s",
+                    weatherMidKey, code, date
+            );
+
+            // WebClient 호출
+            String responseBody = webClient.get()
+                    .uri(URI.create(url)) // 자동 인코딩 방지
+                    .retrieve()
+                    .bodyToMono(String.class)
+                    .block();
+
+            // JSON 형식 검증
+            if (!responseBody.trim().startsWith("{") && !responseBody.trim().startsWith("[")) {
+                throw InternalServerError.invalidWeatherResponseFormat(responseBody);
+            }
+
+            return responseBody;
+        } catch (Exception e) {
+            throw InternalServerError.weatherApiError(e.getMessage());
         }
     }
 }

--- a/backend/src/main/java/com/meong9/backend/domain/weather/service/WeatherApiService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/weather/service/WeatherApiService.java
@@ -1,0 +1,135 @@
+package com.meong9.backend.domain.weather.service;
+
+import com.meong9.backend.global.exception.InternalServerError;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.io.IOException;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLEncoder;
+
+
+@Service
+@RequiredArgsConstructor
+public class WeatherApiService {
+
+    private final WebClient webClient;
+
+    @Value("${weather.mid.encoding-key}")
+    private String weatherMidKey; // 중기 예보 키
+
+    public String getWeatherForecastMid(String code, String date) {
+        try {
+            // URL 빌드
+            StringBuilder urlBuilder = new StringBuilder("http://apis.data.go.kr/1360000/MidFcstInfoService/getMidLandFcst");
+            urlBuilder.append("?").append("serviceKey").append("=").append(weatherMidKey);
+            urlBuilder.append("&").append(URLEncoder.encode("pageNo", "UTF-8")).append("=").append(URLEncoder.encode("1", "UTF-8"));
+            urlBuilder.append("&").append(URLEncoder.encode("numOfRows", "UTF-8")).append("=").append(URLEncoder.encode("10", "UTF-8"));
+            urlBuilder.append("&").append(URLEncoder.encode("dataType", "UTF-8")).append("=").append(URLEncoder.encode("JSON", "UTF-8"));
+            urlBuilder.append("&").append(URLEncoder.encode("regId", "UTF-8")).append("=").append(URLEncoder.encode(code, "UTF-8"));
+            urlBuilder.append("&").append(URLEncoder.encode("tmFc", "UTF-8")).append("=").append(URLEncoder.encode(date, "UTF-8"));
+
+            // URL 객체 생성
+            URL url = new URL(urlBuilder.toString());
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestMethod("GET");
+            conn.setRequestProperty("Content-type", "application/json");
+
+            System.out.println("Request URL: " + urlBuilder.toString());
+
+            // 응답 코드 확인
+            int responseCode = conn.getResponseCode();
+            System.out.println("Response code: " + responseCode);
+
+            // 응답 처리
+            BufferedReader rd;
+            if (responseCode >= 200 && responseCode <= 300) {
+                rd = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+            } else {
+                rd = new BufferedReader(new InputStreamReader(conn.getErrorStream()));
+            }
+
+            // 응답 데이터를 읽어 들이기
+            StringBuilder response = new StringBuilder();
+            String line;
+            while ((line = rd.readLine()) != null) {
+                response.append(line);
+            }
+            rd.close();
+            conn.disconnect();
+
+            // JSON 형식인지 확인
+            String responseBody = response.toString().trim();
+            if (!responseBody.startsWith("{") && !responseBody.startsWith("[")) {
+                System.out.println("Received non-JSON response: " + responseBody);
+                throw InternalServerError.weatherApiError("Invalid response format: " + responseBody);
+            }
+
+            return responseBody;
+        } catch (IOException e) {
+            throw new RuntimeException("데이터를 읽어오는 데 오류 발생", e);
+        }
+    }
+
+    // 단기 예보
+    public String getWeatherForecastST(String[] xy, String date) {
+        try {
+            // URL 빌드
+            StringBuilder urlBuilder = new StringBuilder("http://apis.data.go.kr/1360000/VilageFcstInfoService_2.0/getVilageFcst");
+            urlBuilder.append("?").append("serviceKey").append("=").append(weatherMidKey);
+            urlBuilder.append("&").append(URLEncoder.encode("pageNo", "UTF-8")).append("=").append(URLEncoder.encode("1", "UTF-8")); // 페이지 번호
+            urlBuilder.append("&").append(URLEncoder.encode("numOfRows", "UTF-8")).append("=").append(URLEncoder.encode("798", "UTF-8")); // 한 페이지 결과 수
+            urlBuilder.append("&").append(URLEncoder.encode("dataType", "UTF-8")).append("=").append(URLEncoder.encode("JSON", "UTF-8")); // 데이터 형식
+            urlBuilder.append("&").append(URLEncoder.encode("base_date", "UTF-8")).append("=").append(URLEncoder.encode(date, "UTF-8")); // 발표 날짜
+            urlBuilder.append("&").append(URLEncoder.encode("base_time", "UTF-8")).append("=").append(URLEncoder.encode("1400", "UTF-8")); // 발표 시간
+            urlBuilder.append("&").append(URLEncoder.encode("nx", "UTF-8")).append("=").append(URLEncoder.encode(xy[0], "UTF-8")); // 예보 지점 X 좌표 값
+            urlBuilder.append("&").append(URLEncoder.encode("ny", "UTF-8")).append("=").append(URLEncoder.encode(xy[1], "UTF-8")); // 예보 지점 Y 좌표 값
+
+            // URL 객체 생성
+            URL url = new URL(urlBuilder.toString());
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestMethod("GET");
+            conn.setRequestProperty("Content-type", "application/json");
+
+            System.out.println("Request URL: " + urlBuilder.toString());
+
+            // 응답 코드 확인
+            int responseCode = conn.getResponseCode();
+            System.out.println("Response code: " + responseCode);
+
+            // 응답 처리
+            BufferedReader rd;
+            if (responseCode >= 200 && responseCode <= 300) {
+                rd = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+            } else {
+                rd = new BufferedReader(new InputStreamReader(conn.getErrorStream()));
+            }
+
+            StringBuilder response = new StringBuilder();
+            String line;
+            while ((line = rd.readLine()) != null) {
+                response.append(line);
+            }
+            rd.close();
+            conn.disconnect();
+
+            // JSON 형식인지 확인
+            String responseBody = response.toString().trim();
+            if (!responseBody.startsWith("{") && !responseBody.startsWith("[")) {
+                System.out.println("Received non-JSON response: " + responseBody);
+                throw InternalServerError.weatherApiError("Invalid response format: " + responseBody);
+            }
+
+            return responseBody;
+        } catch (IOException e) {
+            throw new RuntimeException("데이터를 읽어오는 데 오류 발생", e);
+        }
+    }
+}
+

--- a/backend/src/main/java/com/meong9/backend/domain/weather/service/WeatherService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/weather/service/WeatherService.java
@@ -37,8 +37,8 @@ public class WeatherService {
     private final WeatherApiService weatherApiService;
 
     // 지역 별 날씨 데이터 (기상청  api 호출)
-    @Scheduled(cron = "0 0 6 * * ?") // 새벽 6시
-//    @Scheduled(cron = "0 * * * * ?")
+//    @Scheduled(cron = "0 0 6 * * ?") // 새벽 6시
+    @Scheduled(cron = "0 * * * * ?")
     public void fetchAndStoreWeatherData() {
         for (Map.Entry<String, String> entry : RegionMapper.getWeatherRegionAll().entrySet()) {
             try {
@@ -155,20 +155,33 @@ public class WeatherService {
         JsonNode firstItem = itemsNodeMid.get(0);
         ObjectNode summary = objectMapper.createObjectNode();
 
+        // Weather codes 처리
         for (int i = 0; i < weatherCodes.size(); i++) {
-            summary.put("day" + (i + 1), weatherCodes.get(i));
+            String weather = weatherCodes.get(i);
+            summary.put("day" + (i + 1), extractLastWord(weather));
         }
 
-        summary.put("day4", firstItem.path("wf4Pm").asText());
-        summary.put("day5", firstItem.path("wf5Pm").asText());
-        summary.put("day6", firstItem.path("wf6Pm").asText());
-        summary.put("day7", firstItem.path("wf7Pm").asText());
-        summary.put("day8", firstItem.path("wf8").asText());
-        summary.put("day9", firstItem.path("wf9").asText());
-        summary.put("day10", firstItem.path("wf10").asText());
+        // JSON 노드에서 날씨 데이터 처리
+        summary.put("day4", extractLastWord(firstItem.path("wf4Pm").asText()));
+        summary.put("day5", extractLastWord(firstItem.path("wf5Pm").asText()));
+        summary.put("day6", extractLastWord(firstItem.path("wf6Pm").asText()));
+        summary.put("day7", extractLastWord(firstItem.path("wf7Pm").asText()));
+        summary.put("day8", extractLastWord(firstItem.path("wf8").asText()));
+        summary.put("day9", extractLastWord(firstItem.path("wf9").asText()));
+        summary.put("day10", extractLastWord(firstItem.path("wf10").asText()));
 
         return summary;
     }
+
+    // 마지막 단어 추출 메서드
+    private String extractLastWord(String weather) {
+        if (weather == null || weather.isEmpty()) {
+            return weather; // null 또는 빈 문자열 처리
+        }
+        String[] words = weather.split(" ");
+        return words[words.length - 1];
+    }
+
 
     // 레디스에 저장
     private void saveToRedis(String region, ObjectNode weatherSummary) {

--- a/backend/src/main/java/com/meong9/backend/domain/weather/service/WeatherService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/weather/service/WeatherService.java
@@ -1,0 +1,62 @@
+package com.meong9.backend.domain.weather.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+public class WeatherService {
+
+    private final WebClient webClient;
+
+    @Value("${weather.mid.decoding-key}")
+    private String weatherMidKey; // 중기 예보 키
+
+//    public String getWeatherForecast() {
+//        // API 호출
+//        return webClient.get()
+//                .uri(uriBuilder -> uriBuilder
+////                        .path("/1360000/MidFcstInfoService/getMidFcst")
+////                        .path("/1360000/MidFcstInfoService")
+////                        .path("/1360000/MidFcstInfoService/getMidLandFcst") // 중기 육상 예보
+//                        .path("/1360000/VilageFcstInfoService_2.0/getVilageFcst")
+//                        .queryParam("serviceKey", weatherMidKey) // 서비스키 입력
+//                        .queryParam("pageNo", "1")
+//                        .queryParam("numOfRows", "10")
+//                        .queryParam("dataType", "JSON") // JSON 형식으로 요청
+//                        .queryParam("regId", "11B00000") // 전국 예보
+//                        .queryParam("tmFc", "202412020600") // YYYYMMDDHHMM
+//                        .build())
+//                .retrieve()
+//
+//                .bodyToMono(String.class) // 응답을 String으로 받음
+//                .block(); // 동기 방식으로 처리
+//    }
+
+    public String getWeatherForecast() {
+        // API 호출
+        return webClient.get()
+                .uri(uriBuilder -> uriBuilder
+//                        .path("/1360000/MidFcstInfoService/getMidFcst")
+//                        .path("/1360000/MidFcstInfoService")
+//                        .path("/1360000/MidFcstInfoService/getMidLandFcst") // 중기 육상 예보
+                        .path("/1360000/VilageFcstInfoService_2.0/getVilageFcst")
+                        .queryParam("serviceKey", weatherMidKey) // 서비스키 입력
+                        .queryParam("pageNo", "1")
+                        .queryParam("numOfRows", "100")
+                        .queryParam("dataType", "JSON") // JSON 형식으로 요청
+                        .queryParam("base_date", "20241202")
+                        .queryParam("base_time", "0500")
+                        .queryParam("nx", "55")
+                        .queryParam("ny", "127")
+                        .build())
+                .retrieve()
+
+                .bodyToMono(String.class) // 응답을 String으로 받음
+                .block(); // 동기 방식으로 처리
+    }
+}
+

--- a/backend/src/main/java/com/meong9/backend/domain/weather/service/WeatherService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/weather/service/WeatherService.java
@@ -4,7 +4,20 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriComponentsBuilder;
 import reactor.core.publisher.Mono;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicReference;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLEncoder;
+
 
 @Service
 @RequiredArgsConstructor
@@ -12,51 +25,103 @@ public class WeatherService {
 
     private final WebClient webClient;
 
-    @Value("${weather.mid.decoding-key}")
+    @Value("${weather.mid.encoding-key}")
     private String weatherMidKey; // 중기 예보 키
 
-//    public String getWeatherForecast() {
-//        // API 호출
-//        return webClient.get()
-//                .uri(uriBuilder -> uriBuilder
-////                        .path("/1360000/MidFcstInfoService/getMidFcst")
-////                        .path("/1360000/MidFcstInfoService")
-////                        .path("/1360000/MidFcstInfoService/getMidLandFcst") // 중기 육상 예보
-//                        .path("/1360000/VilageFcstInfoService_2.0/getVilageFcst")
-//                        .queryParam("serviceKey", weatherMidKey) // 서비스키 입력
-//                        .queryParam("pageNo", "1")
-//                        .queryParam("numOfRows", "10")
-//                        .queryParam("dataType", "JSON") // JSON 형식으로 요청
-//                        .queryParam("regId", "11B00000") // 전국 예보
-//                        .queryParam("tmFc", "202412020600") // YYYYMMDDHHMM
-//                        .build())
-//                .retrieve()
-//
-//                .bodyToMono(String.class) // 응답을 String으로 받음
-//                .block(); // 동기 방식으로 처리
-//    }
-
     public String getWeatherForecast() {
-        // API 호출
-        return webClient.get()
-                .uri(uriBuilder -> uriBuilder
-//                        .path("/1360000/MidFcstInfoService/getMidFcst")
-//                        .path("/1360000/MidFcstInfoService")
-//                        .path("/1360000/MidFcstInfoService/getMidLandFcst") // 중기 육상 예보
-                        .path("/1360000/VilageFcstInfoService_2.0/getVilageFcst")
-                        .queryParam("serviceKey", weatherMidKey) // 서비스키 입력
-                        .queryParam("pageNo", "1")
-                        .queryParam("numOfRows", "100")
-                        .queryParam("dataType", "JSON") // JSON 형식으로 요청
-                        .queryParam("base_date", "20241202")
-                        .queryParam("base_time", "0500")
-                        .queryParam("nx", "55")
-                        .queryParam("ny", "127")
-                        .build())
-                .retrieve()
+        try {
+            // URL 빌드
+            StringBuilder urlBuilder = new StringBuilder("http://apis.data.go.kr/1360000/MidFcstInfoService/getMidLandFcst");
+            urlBuilder.append("?").append("serviceKey").append("=").append(weatherMidKey);
+            urlBuilder.append("&").append(URLEncoder.encode("pageNo", "UTF-8")).append("=").append(URLEncoder.encode("1", "UTF-8")); // 페이지 번호
+            urlBuilder.append("&").append(URLEncoder.encode("numOfRows", "UTF-8")).append("=").append(URLEncoder.encode("10", "UTF-8")); // 한 페이지 결과 수
+            urlBuilder.append("&").append(URLEncoder.encode("dataType", "UTF-8")).append("=").append(URLEncoder.encode("JSON", "UTF-8")); // 데이터 형식
+            urlBuilder.append("&").append(URLEncoder.encode("regId", "UTF-8")).append("=").append(URLEncoder.encode("11B00000", "UTF-8")); // 지역 코드
+            urlBuilder.append("&").append(URLEncoder.encode("tmFc", "UTF-8")).append("=").append(URLEncoder.encode("202412030600", "UTF-8")); // 발표 시각
 
-                .bodyToMono(String.class) // 응답을 String으로 받음
-                .block(); // 동기 방식으로 처리
+            // URL 객체 생성
+            URL url = new URL(urlBuilder.toString());
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestMethod("GET");
+            conn.setRequestProperty("Content-type", "application/json");
+
+            System.out.println("Request URL: " + urlBuilder.toString());
+
+            // 응답 코드 확인
+            int responseCode = conn.getResponseCode();
+            System.out.println("Response code: " + responseCode);
+
+            // 응답 처리
+            BufferedReader rd;
+            if (responseCode >= 200 && responseCode <= 300) {
+                rd = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+            } else {
+                rd = new BufferedReader(new InputStreamReader(conn.getErrorStream()));
+            }
+
+            StringBuilder response = new StringBuilder();
+            String line;
+            while ((line = rd.readLine()) != null) {
+                response.append(line);
+            }
+            rd.close();
+            conn.disconnect();
+
+            // 응답 반환
+            return response.toString();
+        } catch (IOException e) {
+            e.printStackTrace();
+            throw new RuntimeException("Failed to call Weather API", e);
+        }
+    }
+
+    public String getWeatherForecast2() {
+        try {
+            // URL 빌드
+            StringBuilder urlBuilder = new StringBuilder("http://apis.data.go.kr/1360000/VilageFcstInfoService_2.0/getVilageFcst");
+            urlBuilder.append("?").append("serviceKey").append("=").append(weatherMidKey);
+            urlBuilder.append("&").append(URLEncoder.encode("pageNo", "UTF-8")).append("=").append(URLEncoder.encode("1", "UTF-8")); // 페이지 번호
+            urlBuilder.append("&").append(URLEncoder.encode("numOfRows", "UTF-8")).append("=").append(URLEncoder.encode("10", "UTF-8")); // 한 페이지 결과 수
+            urlBuilder.append("&").append(URLEncoder.encode("dataType", "UTF-8")).append("=").append(URLEncoder.encode("JSON", "UTF-8")); // 데이터 형식
+            urlBuilder.append("&").append(URLEncoder.encode("base_date", "UTF-8")).append("=").append(URLEncoder.encode("20241203", "UTF-8")); // 발표 날짜
+            urlBuilder.append("&").append(URLEncoder.encode("base_time", "UTF-8")).append("=").append(URLEncoder.encode("0500", "UTF-8")); // 발표 시간
+            urlBuilder.append("&").append(URLEncoder.encode("nx", "UTF-8")).append("=").append(URLEncoder.encode("55", "UTF-8")); // 예보 지점 X 좌표 값
+            urlBuilder.append("&").append(URLEncoder.encode("ny", "UTF-8")).append("=").append(URLEncoder.encode("127", "UTF-8")); // 예보 지점 Y 좌표 값
+
+            // URL 객체 생성
+            URL url = new URL(urlBuilder.toString());
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestMethod("GET");
+            conn.setRequestProperty("Content-type", "application/json");
+
+            System.out.println("Request URL: " + urlBuilder.toString());
+
+            // 응답 코드 확인
+            int responseCode = conn.getResponseCode();
+            System.out.println("Response code: " + responseCode);
+
+            // 응답 처리
+            BufferedReader rd;
+            if (responseCode >= 200 && responseCode <= 300) {
+                rd = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+            } else {
+                rd = new BufferedReader(new InputStreamReader(conn.getErrorStream()));
+            }
+
+            StringBuilder response = new StringBuilder();
+            String line;
+            while ((line = rd.readLine()) != null) {
+                response.append(line);
+            }
+            rd.close();
+            conn.disconnect();
+
+            // 응답 반환
+            return response.toString();
+        } catch (IOException e) {
+            e.printStackTrace();
+            throw new RuntimeException("Failed to call Weather API", e);
+        }
     }
 }
 

--- a/backend/src/main/java/com/meong9/backend/domain/weather/service/WeatherService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/weather/service/WeatherService.java
@@ -1,5 +1,6 @@
 package com.meong9.backend.domain.weather.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -8,6 +9,7 @@ import com.meong9.backend.global.exception.InternalServerError;
 import com.meong9.backend.global.exception.NotFoundException;
 import com.meong9.backend.global.utils.RegionMapper;
 import com.meong9.backend.global.utils.WeatherMapper;
+import io.lettuce.core.RedisConnectionException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -37,8 +39,8 @@ public class WeatherService {
     private final WeatherApiService weatherApiService;
 
     // 지역 별 날씨 데이터 (기상청  api 호출)
-    @Scheduled(cron = "0 0 6 * * ?") // 새벽 6시
-//    @Scheduled(cron = "0 * * * * ?")
+//    @Scheduled(cron = "0 0 6 * * ?") // 새벽 6시
+    @Scheduled(cron = "0 * * * * ?")
     public void fetchAndStoreWeatherData() {
         for (Map.Entry<String, String> entry : RegionMapper.getWeatherRegionAll().entrySet()) {
             retryProcessRegionWeather(entry.getKey(), entry.getValue(), 3); // 최대 3번 재시도
@@ -63,8 +65,14 @@ public class WeatherService {
             weatherDto.setRegionName(region);
 
             return weatherDto;
-        } catch (Exception e) {
-            throw InternalServerError.redisMappingError(e.getMessage());
+        } catch (JsonProcessingException e) {
+            // json 파싱 오류
+            throw InternalServerError.parseJsonError(e.getMessage());
+        } catch (RedisConnectionException e) {
+            // redis 연결 오류
+            throw InternalServerError.redisConnectError(e.getMessage());
+        } catch (Exception e){
+            throw new RuntimeException("날씨 데이터 조회에 실패" + e.getMessage());
         }
     }
 
@@ -199,7 +207,7 @@ public class WeatherService {
     // 레디스에 저장
     private void saveToRedis(String region, ObjectNode weatherSummary) {
         String key = WEATHER_KEY + RegionMapper.getRegionEng(region);
-        redisTemplate.opsForValue().setIfAbsent(key, weatherSummary.toString(), Duration.ofHours(24));
+        redisTemplate.opsForValue().set(key, weatherSummary.toString(), Duration.ofHours(24));
         log.info("날씨 정보 redis에 저장 완료!");
     }
 

--- a/backend/src/main/java/com/meong9/backend/domain/weather/service/WeatherService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/weather/service/WeatherService.java
@@ -37,8 +37,8 @@ public class WeatherService {
     private final WeatherApiService weatherApiService;
 
     // 지역 별 날씨 데이터 (기상청  api 호출)
-//    @Scheduled(cron = "0 0 7 * * ?")
-    @Scheduled(cron = "0 * * * * ?")
+    @Scheduled(cron = "0 0 6 * * ?") // 새벽 6시
+//    @Scheduled(cron = "0 * * * * ?")
     public void fetchAndStoreWeatherData() {
         for (Map.Entry<String, String> entry : RegionMapper.getWeatherRegionAll().entrySet()) {
             try {

--- a/backend/src/main/java/com/meong9/backend/domain/weather/service/WeatherService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/weather/service/WeatherService.java
@@ -1,127 +1,180 @@
 package com.meong9.backend.domain.weather.service;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.meong9.backend.domain.weather.dto.WeatherDto;
+import com.meong9.backend.global.exception.InternalServerError;
+import com.meong9.backend.global.exception.NotFoundException;
+import com.meong9.backend.global.utils.RegionMapper;
+import com.meong9.backend.global.utils.WeatherMapper;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
-import org.springframework.web.reactive.function.client.WebClient;
-import org.springframework.web.util.UriComponentsBuilder;
-import reactor.core.publisher.Mono;
-import org.springframework.web.util.UriComponentsBuilder;
+import org.springframework.transaction.annotation.Transactional;
 
-import java.io.IOException;
-import java.util.concurrent.atomic.AtomicReference;
-
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
-import java.io.IOException;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.net.URLEncoder;
-
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class WeatherService {
 
-    private final WebClient webClient;
+    private static final String WEATHER_KEY = "weather:";
+    private static final DateTimeFormatter FULL_DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMddHHmm");
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
 
-    @Value("${weather.mid.encoding-key}")
-    private String weatherMidKey; // 중기 예보 키
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final ObjectMapper objectMapper;
+    private final WeatherApiService weatherApiService;
 
-    public String getWeatherForecast() {
-        try {
-            // URL 빌드
-            StringBuilder urlBuilder = new StringBuilder("http://apis.data.go.kr/1360000/MidFcstInfoService/getMidLandFcst");
-            urlBuilder.append("?").append("serviceKey").append("=").append(weatherMidKey);
-            urlBuilder.append("&").append(URLEncoder.encode("pageNo", "UTF-8")).append("=").append(URLEncoder.encode("1", "UTF-8")); // 페이지 번호
-            urlBuilder.append("&").append(URLEncoder.encode("numOfRows", "UTF-8")).append("=").append(URLEncoder.encode("10", "UTF-8")); // 한 페이지 결과 수
-            urlBuilder.append("&").append(URLEncoder.encode("dataType", "UTF-8")).append("=").append(URLEncoder.encode("JSON", "UTF-8")); // 데이터 형식
-            urlBuilder.append("&").append(URLEncoder.encode("regId", "UTF-8")).append("=").append(URLEncoder.encode("11B00000", "UTF-8")); // 지역 코드
-            urlBuilder.append("&").append(URLEncoder.encode("tmFc", "UTF-8")).append("=").append(URLEncoder.encode("202412030600", "UTF-8")); // 발표 시각
-
-            // URL 객체 생성
-            URL url = new URL(urlBuilder.toString());
-            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-            conn.setRequestMethod("GET");
-            conn.setRequestProperty("Content-type", "application/json");
-
-            System.out.println("Request URL: " + urlBuilder.toString());
-
-            // 응답 코드 확인
-            int responseCode = conn.getResponseCode();
-            System.out.println("Response code: " + responseCode);
-
-            // 응답 처리
-            BufferedReader rd;
-            if (responseCode >= 200 && responseCode <= 300) {
-                rd = new BufferedReader(new InputStreamReader(conn.getInputStream()));
-            } else {
-                rd = new BufferedReader(new InputStreamReader(conn.getErrorStream()));
+    // 지역 별 날씨 데이터 (기상청  api 호출)
+//    @Scheduled(cron = "0 0 7 * * ?")
+    @Scheduled(cron = "0 * * * * ?")
+    public void fetchAndStoreWeatherData() {
+        for (Map.Entry<String, String> entry : RegionMapper.getWeatherRegionAll().entrySet()) {
+            try {
+                processRegionWeather(entry.getKey(), entry.getValue());
+            } catch (Exception e) {
+                System.err.println("지역 처리 중 오류가 발생: " + entry.getKey());
+                e.printStackTrace();
             }
-
-            StringBuilder response = new StringBuilder();
-            String line;
-            while ((line = rd.readLine()) != null) {
-                response.append(line);
-            }
-            rd.close();
-            conn.disconnect();
-
-            // 응답 반환
-            return response.toString();
-        } catch (IOException e) {
-            e.printStackTrace();
-            throw new RuntimeException("Failed to call Weather API", e);
         }
     }
 
-    public String getWeatherForecast2() {
+    // 날씨 데이터 조회
+    @Transactional(readOnly = true)
+    public WeatherDto getWeatherData(String region) {
         try {
-            // URL 빌드
-            StringBuilder urlBuilder = new StringBuilder("http://apis.data.go.kr/1360000/VilageFcstInfoService_2.0/getVilageFcst");
-            urlBuilder.append("?").append("serviceKey").append("=").append(weatherMidKey);
-            urlBuilder.append("&").append(URLEncoder.encode("pageNo", "UTF-8")).append("=").append(URLEncoder.encode("1", "UTF-8")); // 페이지 번호
-            urlBuilder.append("&").append(URLEncoder.encode("numOfRows", "UTF-8")).append("=").append(URLEncoder.encode("10", "UTF-8")); // 한 페이지 결과 수
-            urlBuilder.append("&").append(URLEncoder.encode("dataType", "UTF-8")).append("=").append(URLEncoder.encode("JSON", "UTF-8")); // 데이터 형식
-            urlBuilder.append("&").append(URLEncoder.encode("base_date", "UTF-8")).append("=").append(URLEncoder.encode("20241203", "UTF-8")); // 발표 날짜
-            urlBuilder.append("&").append(URLEncoder.encode("base_time", "UTF-8")).append("=").append(URLEncoder.encode("0500", "UTF-8")); // 발표 시간
-            urlBuilder.append("&").append(URLEncoder.encode("nx", "UTF-8")).append("=").append(URLEncoder.encode("55", "UTF-8")); // 예보 지점 X 좌표 값
-            urlBuilder.append("&").append(URLEncoder.encode("ny", "UTF-8")).append("=").append(URLEncoder.encode("127", "UTF-8")); // 예보 지점 Y 좌표 값
+            // redis 키
+            String key = String.format("weather:%s", RegionMapper.getRegionEng(region));
 
-            // URL 객체 생성
-            URL url = new URL(urlBuilder.toString());
-            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-            conn.setRequestMethod("GET");
-            conn.setRequestProperty("Content-type", "application/json");
+            String jsonString = (String) redisTemplate.opsForValue().get(key);
+            WeatherDto weatherDto = objectMapper.readValue(jsonString, WeatherDto.class);
+            weatherDto.setRegionName(region);
 
-            System.out.println("Request URL: " + urlBuilder.toString());
-
-            // 응답 코드 확인
-            int responseCode = conn.getResponseCode();
-            System.out.println("Response code: " + responseCode);
-
-            // 응답 처리
-            BufferedReader rd;
-            if (responseCode >= 200 && responseCode <= 300) {
-                rd = new BufferedReader(new InputStreamReader(conn.getInputStream()));
-            } else {
-                rd = new BufferedReader(new InputStreamReader(conn.getErrorStream()));
-            }
-
-            StringBuilder response = new StringBuilder();
-            String line;
-            while ((line = rd.readLine()) != null) {
-                response.append(line);
-            }
-            rd.close();
-            conn.disconnect();
-
-            // 응답 반환
-            return response.toString();
-        } catch (IOException e) {
-            e.printStackTrace();
-            throw new RuntimeException("Failed to call Weather API", e);
+            return weatherDto;
+        } catch (Exception e) {
+            throw new RuntimeException("Redis 데이터를 DTO로 매핑하는 데 실패했습니다.", e);
         }
     }
+
+    // 날씨 데이터 처리
+    private void processRegionWeather(String region, String code) {
+        String dateFormatMid = getFixedTime(6, 0).format(FULL_DATE_TIME_FORMATTER);
+        String dateFormatST = getYesterday().format(DATE_FORMATTER);
+
+        String[] xy = RegionMapper.getWeatherXYRegion(region);
+
+        String responseMid = weatherApiService.getWeatherForecastMid(code, dateFormatMid);
+        String responseST = weatherApiService.getWeatherForecastST(xy, dateFormatST);
+
+        // 단기
+        List<String> weatherCodes = parseShortTermWeather(responseST);
+
+        // 중기
+        JsonNode itemsNodeMid = parseJsonNode(responseMid, "response", "body", "items", "item");
+
+        if (itemsNodeMid.isArray() && itemsNodeMid.size() > 0) {
+            // 저장 전 매핑
+            ObjectNode weatherSummary = createWeatherSummary(itemsNodeMid, weatherCodes);
+
+            // redis에 저장
+            saveToRedis(region, weatherSummary);
+        } else {
+            throw NotFoundException.entityNotFound("중기 예보 데이터");
+        }
+    }
+
+    private LocalDateTime getFixedTime(int hour, int minute) {
+        return LocalDateTime.now().withHour(hour).withMinute(minute);
+    }
+
+    private LocalDate getYesterday() {
+        return LocalDate.now().minusDays(1);
+    }
+
+    private JsonNode parseJsonNode(String jsonString, String... paths) {
+        try {
+            JsonNode node = objectMapper.readTree(jsonString);
+            for (String path : paths) {
+                node = node.path(path);
+            }
+            return node;
+        } catch (Exception e) {
+            throw InternalServerError.weatherApiError("JSON 데이터 파싱 중 오류 발생: " + e.getMessage());
+        }
+    }
+
+    // 단기 데이터 파싱
+    private List<String> parseShortTermWeather(String response) {
+        JsonNode itemsNode = parseJsonNode(response, "response", "body", "items", "item");
+        List<String> weatherCodes = new ArrayList<>();
+        List<LocalDate> targetDates = List.of(LocalDate.now(), LocalDate.now().plusDays(1), LocalDate.now().plusDays(2));
+
+        for (LocalDate targetDate : targetDates) {
+            String targetDateString = targetDate.format(DATE_FORMATTER);
+            weatherCodes.add(findWeatherCode(itemsNode, targetDateString));
+        }
+        return weatherCodes;
+    }
+
+    private String findWeatherCode(JsonNode itemsNode, String targetDate) {
+        String ptyValue = null;
+        String skyValue = null;
+
+        for (JsonNode item : itemsNode) {
+            String category = item.path("category").asText();
+            String fcstDate = item.path("fcstDate").asText();
+            String fcstTime = item.path("fcstTime").asText();
+
+            // 15시 기준 데이터 반환
+            if (fcstDate.equals(targetDate) && "1500".equals(fcstTime)) {
+                // 강수 없음이면 SKY 코드, 강수 있으면 PTY 코드
+                if ("PTY".equals(category)) ptyValue = item.path("fcstValue").asText();
+                if ("SKY".equals(category)) skyValue = item.path("fcstValue").asText();
+            }
+        }
+
+        // 날씨 코드 텍스트로 매핑
+        if (ptyValue != null && !"0".equals(ptyValue)) return WeatherMapper.getWeatherPtyCode(ptyValue);
+        if (skyValue != null) return WeatherMapper.getWeatherSkyCode(skyValue);
+        return "";
+    }
+
+    // 저장 전 매핑
+    private ObjectNode createWeatherSummary(JsonNode itemsNodeMid, List<String> weatherCodes) {
+        JsonNode firstItem = itemsNodeMid.get(0);
+        ObjectNode summary = objectMapper.createObjectNode();
+
+        for (int i = 0; i < weatherCodes.size(); i++) {
+            summary.put("day" + (i + 1), weatherCodes.get(i));
+        }
+
+        summary.put("day4", firstItem.path("wf4Pm").asText());
+        summary.put("day5", firstItem.path("wf5Pm").asText());
+        summary.put("day6", firstItem.path("wf6Pm").asText());
+        summary.put("day7", firstItem.path("wf7Pm").asText());
+        summary.put("day8", firstItem.path("wf8").asText());
+        summary.put("day9", firstItem.path("wf9").asText());
+        summary.put("day10", firstItem.path("wf10").asText());
+
+        return summary;
+    }
+
+    // 레디스에 저장
+    private void saveToRedis(String region, ObjectNode weatherSummary) {
+        String key = WEATHER_KEY + RegionMapper.getRegionEng(region);
+        redisTemplate.opsForValue().setIfAbsent(key, weatherSummary.toString(), Duration.ofHours(24));
+        log.info("redis에 저장 완료!");
+    }
+
 }
-

--- a/backend/src/main/java/com/meong9/backend/domain/weather/service/WeatherService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/weather/service/WeatherService.java
@@ -37,8 +37,8 @@ public class WeatherService {
     private final WeatherApiService weatherApiService;
 
     // 지역 별 날씨 데이터 (기상청  api 호출)
-//    @Scheduled(cron = "0 0 6 * * ?") // 새벽 6시
-    @Scheduled(cron = "0 * * * * ?")
+    @Scheduled(cron = "0 0 6 * * ?") // 새벽 6시
+//    @Scheduled(cron = "0 * * * * ?")
     public void fetchAndStoreWeatherData() {
         for (Map.Entry<String, String> entry : RegionMapper.getWeatherRegionAll().entrySet()) {
             try {

--- a/backend/src/main/java/com/meong9/backend/domain/weather/service/WeatherService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/weather/service/WeatherService.java
@@ -39,8 +39,8 @@ public class WeatherService {
     private final WeatherApiService weatherApiService;
 
     // 지역 별 날씨 데이터 (기상청  api 호출)
-//    @Scheduled(cron = "0 0 6 * * ?") // 새벽 6시
-    @Scheduled(cron = "0 * * * * ?")
+    @Scheduled(cron = "0 0 6 * * ?") // 새벽 6시
+//    @Scheduled(cron = "0 * * * * ?")
     public void fetchAndStoreWeatherData() {
         for (Map.Entry<String, String> entry : RegionMapper.getWeatherRegionAll().entrySet()) {
             retryProcessRegionWeather(entry.getKey(), entry.getValue(), 3); // 최대 3번 재시도

--- a/backend/src/main/java/com/meong9/backend/domain/weather/service/WeatherService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/weather/service/WeatherService.java
@@ -41,12 +41,7 @@ public class WeatherService {
 //    @Scheduled(cron = "0 * * * * ?")
     public void fetchAndStoreWeatherData() {
         for (Map.Entry<String, String> entry : RegionMapper.getWeatherRegionAll().entrySet()) {
-            try {
-                processRegionWeather(entry.getKey(), entry.getValue());
-            } catch (Exception e) {
-                System.err.println("지역 처리 중 오류가 발생: " + entry.getKey());
-                e.printStackTrace();
-            }
+            retryProcessRegionWeather(entry.getKey(), entry.getValue(), 3); // 최대 3번 재시도
         }
     }
 
@@ -58,12 +53,37 @@ public class WeatherService {
             String key = String.format("weather:%s", RegionMapper.getRegionEng(region));
 
             String jsonString = (String) redisTemplate.opsForValue().get(key);
+
+            // redis에 데이터 없으면
+            if(jsonString == null){
+                throw NotFoundException.entityNotFound(region);
+            }
+
             WeatherDto weatherDto = objectMapper.readValue(jsonString, WeatherDto.class);
             weatherDto.setRegionName(region);
 
             return weatherDto;
         } catch (Exception e) {
-            throw new RuntimeException("Redis 데이터를 DTO로 매핑하는 데 실패했습니다.", e);
+            throw InternalServerError.redisMappingError(e.getMessage());
+        }
+    }
+
+
+    // 스케줄러 실패 시 3번 더 해보기
+    private void retryProcessRegionWeather(String regionKey, String regionValue, int maxRetries) {
+        int attempt = 0;
+        while (attempt < maxRetries) {
+            try {
+                processRegionWeather(regionKey, regionValue); // 지역 날씨 처리
+                return; // 성공 시 메서드 종료
+            } catch (Exception e) {
+                attempt++;
+                log.info(String.format("지역 처리 실패: %s (%d/%d 시도)", regionKey, attempt, maxRetries));
+                if (attempt >= maxRetries) {
+                    log.error("최대 재시도 횟수 초과: " + regionKey);
+                    throw InternalServerError.schedulerFailError(e.getMessage());
+                }
+            }
         }
     }
 
@@ -94,15 +114,7 @@ public class WeatherService {
         }
     }
 
-    private LocalDateTime getFixedTime(int hour, int minute) {
-        return LocalDateTime.now().withHour(hour).withMinute(minute);
-    }
-
-    private LocalDate getYesterday() {
-        return LocalDate.now().minusDays(1);
-    }
-
-    private JsonNode parseJsonNode(String jsonString, String... paths) {
+    private JsonNode parseJsonNode(String jsonString, String... paths) { // 가변인자
         try {
             JsonNode node = objectMapper.readTree(jsonString);
             for (String path : paths) {
@@ -127,6 +139,7 @@ public class WeatherService {
         return weatherCodes;
     }
 
+    // 단기 데이터 PTY SKY 수집
     private String findWeatherCode(JsonNode itemsNode, String targetDate) {
         String ptyValue = null;
         String skyValue = null;
@@ -190,4 +203,11 @@ public class WeatherService {
         log.info("날씨 정보 redis에 저장 완료!");
     }
 
+    private LocalDateTime getFixedTime(int hour, int minute) {
+        return LocalDateTime.now().withHour(hour).withMinute(minute);
+    }
+
+    private LocalDate getYesterday() {
+        return LocalDate.now().minusDays(1);
+    }
 }

--- a/backend/src/main/java/com/meong9/backend/domain/weather/service/WeatherService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/weather/service/WeatherService.java
@@ -174,7 +174,7 @@ public class WeatherService {
     private void saveToRedis(String region, ObjectNode weatherSummary) {
         String key = WEATHER_KEY + RegionMapper.getRegionEng(region);
         redisTemplate.opsForValue().setIfAbsent(key, weatherSummary.toString(), Duration.ofHours(24));
-        log.info("redis에 저장 완료!");
+        log.info("날씨 정보 redis에 저장 완료!");
     }
 
 }

--- a/backend/src/main/java/com/meong9/backend/global/auth/config/SecurityConfig.java
+++ b/backend/src/main/java/com/meong9/backend/global/auth/config/SecurityConfig.java
@@ -78,6 +78,8 @@ public class SecurityConfig {
                         new AntPathRequestMatcher("/api/v1/map/places", HttpMethod.GET.name()),
                         new AntPathRequestMatcher("/api/v1/photos", HttpMethod.GET.name()),
                         new AntPathRequestMatcher("/", HttpMethod.GET.name()),
+                        new AntPathRequestMatcher("/api/v1/weather*", HttpMethod.GET.name()),
+
                         new AntPathRequestMatcher("/actuator/health", HttpMethod.GET.name()),
                         new AntPathRequestMatcher("/**", HttpMethod.OPTIONS.name())
                 ));

--- a/backend/src/main/java/com/meong9/backend/global/config/RedisConfig.java
+++ b/backend/src/main/java/com/meong9/backend/global/config/RedisConfig.java
@@ -1,0 +1,64 @@
+package com.meong9.backend.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+import java.util.Set;
+
+@Configuration
+@EnableCaching
+public class RedisConfig {
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
+        redisStandaloneConfiguration.setHostName(redisHost);
+        redisStandaloneConfiguration.setPort(redisPort);
+        LettuceConnectionFactory lettuceConnectionFactory = new LettuceConnectionFactory(redisStandaloneConfiguration);
+        return lettuceConnectionFactory;
+    }
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+        redisTemplate.setEnableTransactionSupport(true);
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
+        return redisTemplate;
+    }
+    @Bean
+    public RedisCacheManager redisCacheManager() {
+        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(
+                                new GenericJackson2JsonRedisSerializer()))
+                .entryTtl(Duration.ofHours(1L));
+        return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(redisConnectionFactory())
+                .cacheDefaults(redisCacheConfiguration).build();
+    }
+    @Bean
+    public HashOperations<String, String, Set<Long>> hashOperations(RedisTemplate<String, Object> redisTemplate) {
+        return redisTemplate.opsForHash();
+    }
+}

--- a/backend/src/main/java/com/meong9/backend/global/config/WebClientConfig.java
+++ b/backend/src/main/java/com/meong9/backend/global/config/WebClientConfig.java
@@ -1,0 +1,15 @@
+package com.meong9.backend.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+    @Bean
+    public WebClient webClient(WebClient.Builder builder) {
+        return builder
+                .baseUrl("http://apis.data.go.kr") // 기본 URL 설정
+                .build();
+    }
+}

--- a/backend/src/main/java/com/meong9/backend/global/exception/BadRequestException.java
+++ b/backend/src/main/java/com/meong9/backend/global/exception/BadRequestException.java
@@ -7,6 +7,8 @@ public class BadRequestException extends BaseException {
     static private final String INVALID_PUPPYID_FORMAT = "유효하지 않은 품종 ID 입니다.";
     static private final String INVALID_FILE_FORMAT = "%s는 유효하지 않은 FileKey 입니다.";
 
+    static private final String INVALID_REGION_NAME_FORMAT = "%s는 유효하지 않은 지역명입니다.";
+
     public BadRequestException(String message) {
         super(HttpStatus.BAD_REQUEST, message);
     }
@@ -21,5 +23,9 @@ public class BadRequestException extends BaseException {
 
     public static BadRequestException invalidFilekeyFormat(String entityName) {
         return new BadRequestException(String.format(INVALID_FILE_FORMAT, entityName));
+    }
+
+    public static BadRequestException invalidRegionNameFormat(String entityName) {
+        return new BadRequestException(String.format(INVALID_REGION_NAME_FORMAT, entityName));
     }
 }

--- a/backend/src/main/java/com/meong9/backend/global/exception/InternalServerError.java
+++ b/backend/src/main/java/com/meong9/backend/global/exception/InternalServerError.java
@@ -7,7 +7,9 @@ public class InternalServerError extends BaseException {
     static private final String WEATHER_API_ERROR = "기상청 api 호출 중 문제가 발생했습니다. %s";
     static private final String INVALID_WEATHER_RESPONSE_FORMAT = "기상청 api의 응답이 JSON이 아닙니다. %s";
 
-    static private final String REDIS_MAPPING_ERROR = "Redis 데이터를 매핑하는 데 실패했습니다. %s";
+    static private final String PARSE_JSON_ERROR = "JSON 파싱에 실패했습니다. %s";
+
+    static private final String REDIS_CONNECT_ERROR = "Redis 연결에 실패했습니다. %s";
     static private final String SCHEDULER_FAIL_ERROR = "스케쥴링 작업에 실패했습니다. %s";
 
 
@@ -27,8 +29,12 @@ public class InternalServerError extends BaseException {
         return new InternalServerError(String.format(INVALID_WEATHER_RESPONSE_FORMAT, entityName));
     }
 
-    public static InternalServerError redisMappingError(String entityName) {
-        return new InternalServerError(String.format(REDIS_MAPPING_ERROR, entityName));
+    public static InternalServerError parseJsonError(String entityName) {
+        return new InternalServerError(String.format(PARSE_JSON_ERROR, entityName));
+    }
+
+    public static InternalServerError redisConnectError(String entityName) {
+        return new InternalServerError(String.format(REDIS_CONNECT_ERROR, entityName));
     }
 
     public static InternalServerError schedulerFailError(String entityName) {

--- a/backend/src/main/java/com/meong9/backend/global/exception/InternalServerError.java
+++ b/backend/src/main/java/com/meong9/backend/global/exception/InternalServerError.java
@@ -5,6 +5,11 @@ import org.springframework.http.HttpStatus;
 public class InternalServerError extends BaseException {
     static private final String PHOTO_PROCESSING_ERROR = "S3에서 사진 저장 중 문제가 발생했습니다.";
     static private final String WEATHER_API_ERROR = "기상청 api 호출 중 문제가 발생했습니다. %s";
+    static private final String INVALID_WEATHER_RESPONSE_FORMAT = "기상청 api의 응답이 JSON이 아닙니다. %s";
+
+    static private final String REDIS_MAPPING_ERROR = "Redis 데이터를 매핑하는 데 실패했습니다. %s";
+    static private final String SCHEDULER_FAIL_ERROR = "스케쥴링 작업에 실패했습니다. %s";
+
 
     public InternalServerError(String message) {
         super(HttpStatus.INTERNAL_SERVER_ERROR, message);
@@ -16,6 +21,18 @@ public class InternalServerError extends BaseException {
 
     public static InternalServerError weatherApiError(String message){
         return new InternalServerError(String.format(WEATHER_API_ERROR, message));
+    }
+
+    public static InternalServerError invalidWeatherResponseFormat(String entityName) {
+        return new InternalServerError(String.format(INVALID_WEATHER_RESPONSE_FORMAT, entityName));
+    }
+
+    public static InternalServerError redisMappingError(String entityName) {
+        return new InternalServerError(String.format(REDIS_MAPPING_ERROR, entityName));
+    }
+
+    public static InternalServerError schedulerFailError(String entityName) {
+        return new InternalServerError(String.format(SCHEDULER_FAIL_ERROR, entityName));
     }
 
 }

--- a/backend/src/main/java/com/meong9/backend/global/exception/InternalServerError.java
+++ b/backend/src/main/java/com/meong9/backend/global/exception/InternalServerError.java
@@ -4,6 +4,7 @@ import org.springframework.http.HttpStatus;
 
 public class InternalServerError extends BaseException {
     static private final String PHOTO_PROCESSING_ERROR = "S3에서 사진 저장 중 문제가 발생했습니다.";
+    static private final String WEATHER_API_ERROR = "기상청 api 호출 중 문제가 발생했습니다. %s";
 
     public InternalServerError(String message) {
         super(HttpStatus.INTERNAL_SERVER_ERROR, message);
@@ -12,4 +13,9 @@ public class InternalServerError extends BaseException {
     public static InternalServerError photoProcessingError() {
         return new InternalServerError(PHOTO_PROCESSING_ERROR);
     }
+
+    public static InternalServerError weatherApiError(String message){
+        return new InternalServerError(String.format(WEATHER_API_ERROR, message));
+    }
+
 }

--- a/backend/src/main/java/com/meong9/backend/global/utils/RegionMapper.java
+++ b/backend/src/main/java/com/meong9/backend/global/utils/RegionMapper.java
@@ -1,0 +1,59 @@
+package com.meong9.backend.global.utils;
+
+import com.meong9.backend.domain.weather.service.WeatherApiService;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class RegionMapper {
+
+    private static final Map<String, String> WEATHER_REGION_CODE_MAP = new HashMap<>();
+    private static final Map<String, String> REGION_NAME_MAP = new HashMap<>();
+    private static final Map<String, String[]> WEATHER_REGION_XY_MAP = new HashMap<>();
+
+
+    static {
+        WEATHER_REGION_CODE_MAP.put("서울", "11B00000");
+        WEATHER_REGION_CODE_MAP.put("경기", "11B00000");
+        WEATHER_REGION_CODE_MAP.put("인천", "11B00000");
+        WEATHER_REGION_CODE_MAP.put("강원", "11D10000");
+        WEATHER_REGION_CODE_MAP.put("충청", "11C20000");
+        WEATHER_REGION_CODE_MAP.put("전라", "11F20000");
+        WEATHER_REGION_CODE_MAP.put("경상", "11H20000");
+        WEATHER_REGION_CODE_MAP.put("제주", "11G00000");
+
+        REGION_NAME_MAP.put("서울", "SEOUL");
+        REGION_NAME_MAP.put("경기", "GYEONGGI");
+        REGION_NAME_MAP.put("인천", "INCHEON");
+        REGION_NAME_MAP.put("강원", "GANGWON");
+        REGION_NAME_MAP.put("충청", "CHUNGCHEONG");
+        REGION_NAME_MAP.put("전라", "JEOLLA");
+        REGION_NAME_MAP.put("경상", "GYEONGSANG");
+        REGION_NAME_MAP.put("제주", "JEJU");
+
+        WEATHER_REGION_XY_MAP.put("서울", new String[]{"60", "127"});
+        WEATHER_REGION_XY_MAP.put("경기", new String[]{"60", "120"});
+        WEATHER_REGION_XY_MAP.put("인천", new String[]{"55", "124"});
+        WEATHER_REGION_XY_MAP.put("강원", new String[]{"93", "132"});
+        WEATHER_REGION_XY_MAP.put("충청", new String[]{"67", "100"});
+        WEATHER_REGION_XY_MAP.put("전라", new String[]{"60", "74"});
+        WEATHER_REGION_XY_MAP.put("경상", new String[]{"89", "90"});
+        WEATHER_REGION_XY_MAP.put("제주", new String[]{"53", "38"});
+    }
+
+    public static String getWeatherRegion(String regionName) {
+        return WEATHER_REGION_CODE_MAP.getOrDefault(regionName, null);
+    }
+
+    public static String[] getWeatherXYRegion(String regionName) {
+        return WEATHER_REGION_XY_MAP.getOrDefault(regionName, null);
+    }
+
+    public static String getRegionEng(String regionName) {
+        return REGION_NAME_MAP.getOrDefault(regionName, null);
+    }
+
+    public static Map<String, String> getWeatherRegionAll(){
+        return WEATHER_REGION_CODE_MAP;
+    }
+}

--- a/backend/src/main/java/com/meong9/backend/global/utils/RegionMapper.java
+++ b/backend/src/main/java/com/meong9/backend/global/utils/RegionMapper.java
@@ -1,7 +1,7 @@
 package com.meong9.backend.global.utils;
 
-import com.meong9.backend.domain.weather.service.WeatherApiService;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -54,6 +54,6 @@ public class RegionMapper {
     }
 
     public static Map<String, String> getWeatherRegionAll(){
-        return WEATHER_REGION_CODE_MAP;
+        return Collections.unmodifiableMap(WEATHER_REGION_CODE_MAP);
     }
 }

--- a/backend/src/main/java/com/meong9/backend/global/utils/WeatherMapper.java
+++ b/backend/src/main/java/com/meong9/backend/global/utils/WeatherMapper.java
@@ -1,0 +1,29 @@
+package com.meong9.backend.global.utils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class WeatherMapper {
+    private static final Map<String, String> WEATHER_SKY_CODE_MAP = new HashMap<>();
+    private static final Map<String, String> WEATHER_PTY_CODE_MAP = new HashMap<>();
+
+    static {
+        // 하늘 상태
+        WEATHER_SKY_CODE_MAP.put("1", "맑음");
+        WEATHER_SKY_CODE_MAP.put("3", "구름많음");
+        WEATHER_SKY_CODE_MAP.put("4", "흐림");
+
+        // 강수 형태
+        WEATHER_PTY_CODE_MAP.put("1", "비");
+        WEATHER_PTY_CODE_MAP.put("2", "비/눈");
+        WEATHER_PTY_CODE_MAP.put("3", "눈");
+        WEATHER_PTY_CODE_MAP.put("4", "소나기");
+    }
+    public static String getWeatherSkyCode(String code) {
+        return WEATHER_SKY_CODE_MAP.getOrDefault(code, null);
+    }
+
+    public static String getWeatherPtyCode(String code) {
+        return WEATHER_PTY_CODE_MAP.getOrDefault(code, null);
+    }
+}

--- a/backend/src/main/resources/application-aws.yml
+++ b/backend/src/main/resources/application-aws.yml
@@ -28,7 +28,7 @@ s3:
 
 kakao:
   client-id: ${KAKAO_REST_API_KEY}
-  redirect-uri: https://mungtivity.vercel.app/login
+  redirect-uri: http://localhost:5173
   client-secret: ${KAKAO_CLIENT_SECRET}
 
 jwt:


### PR DESCRIPTION
## 📋 Summary
<!-- 이 PR에서 변경된 주요 내용을 간략히 작성해주세요. -->
날씨 정보 저장 및 조회

## ✨ Feature Details
| Method | Path                      | Description      |
|--------|---------------------------|------------------|
| GET | /api/v1/weather?region=경기 | 날씨 정보 조회   |


## 💡 Key Considerations
<!-- 구현하면서 고려한 점, 또는 해결한 주요 이슈를 간단히 작성해주세요. -->
스케쥴러로 아침 6시마다 기상청 api 호출
오늘부터 10일 후까지의 날씨 정보를 지역 별로 redis에 저장 (ttl은 24시간)
위 조회 요청 시 redis에 저장된 데이터를 dto 변환 후 반환함

그리고 web client 안 쓴 이유는 web client에서 자동으로 해주는 인코딩이랑 공공데이터에서 준 인코딩 키랑 달라서... 계속 서비스 키 에러 나서 안썼습니다

```
<단기 응답>
SKY: 1(맑음), 3(구름많음), 4(흐림)
PTY: 1(비), 2(비/눈), 3(눈), 4(소나기)

<중기 응답>
- 맑음
- 구름많음, 구름많고 비, 구름많고 눈, 구름많고 비/눈, 구름많고 소나기
- 흐림, 흐리고 비, 흐리고 눈, 흐리고 비/눈, 흐리고 소나기
→ 두 단어가 있는 경우 뒷자리만 반환하게 함 (구름많고 눈 → 눈)
```

그래서 `맑음` `구름많음` `흐림` `비` `비/눈` `눈` `소나기` 만 프론트에서 아이콘 처리하면 될 듯


![image](https://github.com/user-attachments/assets/756e1ade-e8d7-4d34-8cf6-66b4c709117d)


## ✅ Checklist
- [x] 코드를 스스로 검토했나요?
- [x] 필요한 테스트를 추가하고 모두 통과했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올렸나요?
- [x] 커밋 메시지가 컨벤션에 맞나요?
- [x] 필요한 문서를 업데이트했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

- **신규 기능**
  - 날씨 관련 요청을 처리하는 REST 컨트롤러 `WeatherController` 추가.
  - 지역별 날씨 데이터를 가져오는 `WeatherService` 및 API와의 상호작용을 위한 `WeatherApiService` 추가.
  - Redis 캐싱을 위한 `RedisConfig` 클래스 추가.
  - 외부 API 호출을 위한 `WebClientConfig` 클래스 추가.
  - 지역 코드 및 이름을 매핑하는 유틸리티 클래스 `RegionMapper` 및 날씨 코드 매핑 클래스 `WeatherMapper` 추가.
  - 검색 결과를 캡슐화하는 `MapSearchDto` 클래스 및 새로운 검색 엔드포인트 추가.
  - 데이터베이스 연결을 위한 JOOQ 비밀번호 설정 변경.

- **버그 수정**
  - 잘못된 지역 이름 형식에 대한 오류 처리 개선.

- **보안 개선**
  - `/api/v1/weather*` 경로에 대한 보안 필터 우회 설정.

- **구성 변경**
  - Kakao 통합을 위한 `redirect-uri` 값을 로컬 개발 URL로 변경.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->