### PR TITLE
From KAN-93-BE-refactor/transaction into dev : 검색 재리팩토링 

### DIFF
--- a/backend/src/main/java/com/meong9/backend/domain/address/repository/PlcPenAddressRepository.java
+++ b/backend/src/main/java/com/meong9/backend/domain/address/repository/PlcPenAddressRepository.java
@@ -3,6 +3,7 @@ package com.meong9.backend.domain.address.repository;
 import com.meong9.backend.domain.address.entity.PlcPenAddress;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -45,8 +46,14 @@ public interface PlcPenAddressRepository extends JpaRepository<PlcPenAddress, Lo
             WHERE ppa.address.region.regionId IN :regionIds
             AND ppa.type = :typeCode
             """)
-    Page<Long> findFacilityIdsByRegionIdIn(@Param("regionIds") List<Long> regionIds, @Param("typeCode") String typeCode,
-                                           Pageable pageable);
+    List<Long> findFacilityIdsByRegionIdIn(@Param("regionIds") List<Long> regionIds, @Param("typeCode") String typeCode);
+
+    @Query("""
+            SELECT ppa.plcPenId FROM PlcPenAddress ppa
+            WHERE ppa.address.region.regionId IN :regionIds
+            AND ppa.type = :typeCode
+            """)
+    Slice<Long> findFacilityIdsByRegionIdInWithPagination(@Param("regionIds") List<Long> regionIds, @Param("typeCode") String typeCode, Pageable pageable);
 
     @Query("""
         SELECT pa FROM PlcPenAddress pa

--- a/backend/src/main/java/com/meong9/backend/domain/map/service/MapSearchService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/map/service/MapSearchService.java
@@ -50,7 +50,7 @@ public class MapSearchService {
     @Transactional(readOnly = true)
     public MapSearchDto getSearchPlcPen(Member member, String searchWord, Double userLatitude, Double userLongitude, Pageable pageable) {
         // 검색어로 조회
-        Slice<Long> placeIds = searchJooqRepository.findPlaceIdsBySearchWord(searchWord, pageable);
+        Slice<Long> placeIds = searchJooqRepository.findPlaceIdsBySearchWordForMap(searchWord, pageable);
         Slice<Long> pensionIds = searchJooqRepository.findPensionIdsBySearchWord(searchWord, pageable);
 
         // Place와 Pension ID로 조회

--- a/backend/src/main/java/com/meong9/backend/domain/member/service/MemberService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/member/service/MemberService.java
@@ -19,7 +19,7 @@ import com.meong9.backend.global.exception.AuthenticationException;
 import com.meong9.backend.global.exception.NotFoundException;
 import com.meong9.backend.global.mediafile.service.MediaFileService;
 import com.meong9.backend.global.repository.RegionRepository;
-import jakarta.transaction.Transactional;
+import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -31,7 +31,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
-@Transactional
 @RequiredArgsConstructor
 @Slf4j(topic = "MemberService")
 public class MemberService {
@@ -48,6 +47,7 @@ public class MemberService {
     /**
      * refresh token 사용하여 access token 재발급하는 서비스 메서드
      */
+    @Transactional
     public String refreshAccessToken(String refreshToken) {
         if (refreshToken == null) {
             throw AuthenticationException.noRefreshToken();
@@ -73,6 +73,7 @@ public class MemberService {
     /**
      * refresh token의 Max age를 0으로 만들어 로그아웃 시키는 메서드
      */
+    @Transactional
     public void logout(String refreshToken) {
         if (refreshToken == null) {
             throw AuthenticationException.noRefreshToken();
@@ -85,6 +86,7 @@ public class MemberService {
     /**
      * 사용자의 선호 시설을 저장하는 서비스 메서드
      */
+    @Transactional
     public void insertPreferredPlaces(InterestDto dto, Member member) {
         if (dto.getPlaces() == null || dto.getPlaces().isEmpty()) return;
 
@@ -107,6 +109,7 @@ public class MemberService {
     /**
      * 사용자의 선호 지역을 저장하는 서비스 메서드
      */
+    @Transactional
     public void insertPreferredRegions(RegionDto dto, Member member) {
         if (dto.getRegions() == null || dto.getRegions().isEmpty()) return;
 
@@ -129,6 +132,7 @@ public class MemberService {
     /**
      * 사용자 정보를 등록하는 서비스 메서드
      */
+    @Transactional
     public void insertMemberInfo(MultipartFile profileImage,MemberInfoDto dto, Member member) throws IOException {
         updateMember(profileImage, dto, member);
 
@@ -138,6 +142,7 @@ public class MemberService {
     /**
      * 프로필 이미지를 삭제하는 서비스 메서드
      */
+    @Transactional
     public void deleteProfileImage(Member member) {
         mediaFileService.deleteProfileImage(member.getMemberId(),"Mprofile/","_profile.jpg");
     }
@@ -145,6 +150,7 @@ public class MemberService {
     /**
      * 닉네임 중복을 확인하는 서비스 메서드
      */
+    @Transactional(readOnly = true)
     public boolean isNicknameAvailable(String nickname) {
         return !memberRepository.existsByNickname(nickname);
     }
@@ -152,6 +158,7 @@ public class MemberService {
     /**
      * 마이페이지를 조회하는 서비스 메서드
      */
+    @Transactional(readOnly = true)
     public MypageDto getMyPage(Member member) {
         List<Puppy> puppies = puppyRepository.findByMemberIdWithPuppyProfileImage(member.getMemberId());
         Member foundMember = memberRepository.findMemberWithProfileImage(member.getMemberId()).orElseThrow();
@@ -170,6 +177,10 @@ public class MemberService {
                 .build();
     }
 
+    /**
+     * 마이페이지 상세 조회 메서드
+     */
+    @Transactional(readOnly = true)
     public MyPageDetailDto getMyPageDetail(Member member) {
         Member foundMember = memberRepository.findMemberWithProfileImage(member.getMemberId()).orElseThrow();
         return MyPageDetailDto.builder()
@@ -181,6 +192,10 @@ public class MemberService {
                 .build();
     }
 
+    /**
+     * 마이페이지 수정 메서드
+     */
+    @Transactional
     public UpdateMyPageResponseDto updateMyPage(MultipartFile profileImage, MemberInfoDto dto, Member member) throws IOException {
         updateMember(profileImage, dto, member);
 
@@ -203,6 +218,10 @@ public class MemberService {
         }
     }
 
+    /**
+     * 선호 지역 조회 메서드
+     */
+    @Transactional(readOnly = true)
     public RegionDto getPreferredRegions(Member member) {
         List<FavoriteRegion> favRegionList = favoriteRegionRepository.findByMemberId(member.getMemberId());
         return new RegionDto(favRegionList.stream()
@@ -210,6 +229,10 @@ public class MemberService {
                 .collect(Collectors.toSet()));
     }
 
+    /**
+     * 선호 시설 조회 메서드
+     */
+    @Transactional(readOnly = true)
     public InterestDto getPreferredPlaces(Member member) {
         List<PlcFavCategory> favCategoryList = plcFavCategoryRepository.findByMemberId(member.getMemberId());
         return new InterestDto(favCategoryList.stream()

--- a/backend/src/main/java/com/meong9/backend/domain/pension/entity/id/RoomFileId.java
+++ b/backend/src/main/java/com/meong9/backend/domain/pension/entity/id/RoomFileId.java
@@ -2,14 +2,12 @@ package com.meong9.backend.domain.pension.entity.id;
 
 
 import jakarta.persistence.Embeddable;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@EqualsAndHashCode
 @Getter
 public class RoomFileId {
     private Long roomId;

--- a/backend/src/main/java/com/meong9/backend/domain/search/repository/SearchJooqRepository.java
+++ b/backend/src/main/java/com/meong9/backend/domain/search/repository/SearchJooqRepository.java
@@ -8,10 +8,12 @@ import org.springframework.data.domain.Slice;
 import java.util.List;
 
 public interface SearchJooqRepository {
-    List<SearchPlaceDto> searchPlaces(List<Long> regionIds, List<Long> categoryIds, String sizeCode, String typeCode, Long memberId);
+    Slice<SearchPlaceDto> searchPlaces(List<Long> regionIds, List<Long> categoryIds, String sizeCode, String typeCode, Long memberId, Pageable pageable);
     List<SearchPensionDto> searchPensions(List<Long> filteredPensionIds, String startDate, String endDate, String sizeCode, String typeCode, Long memberId);
 
-    Slice<Long> findPlaceIdsBySearchWord(String searchWord, Pageable pageable);
+    Slice<Long> findPlaceIdsBySearchWordForMap(String searchWord, Pageable pageable);
     Slice<Long> findPensionIdsBySearchWord(String searchWord, Pageable pageable);
+
+    List<Long> findPlaceIdsBySearchWord(String searchWord);
 
 }

--- a/backend/src/main/java/com/meong9/backend/domain/search/repository/SearchJooqRepositoryImpl.java
+++ b/backend/src/main/java/com/meong9/backend/domain/search/repository/SearchJooqRepositoryImpl.java
@@ -32,7 +32,8 @@ public class SearchJooqRepositoryImpl implements SearchJooqRepository {
         // 1. 1차 필터링된 장소ID에 더해, 2차로 카테고리 필터링, 3차로 무게 필터링을 마친 filted_placesid_field 생성
         var filteredPlaceSubquery = dsl.select(PLACE.PLACE_ID)
                 .from(PLACE)
-                .where(PLACE.PLC_CATEGORY_ID.in(categoryIds))
+                .where(PLACE.PLACE_ID.in(filteredPlaceIds))
+                .and(PLACE.PLC_CATEGORY_ID.in(categoryIds))
                 .and(getWeightCondition(sizeCode))
                 .limit(pageable.getPageSize() + 1)
                 .offset((int) pageable.getOffset())
@@ -194,7 +195,7 @@ public class SearchJooqRepositoryImpl implements SearchJooqRepository {
                 .where(
                         Arrays.stream(searchWords)
                                 .map(word -> DSL.condition(
-                                        "MATCH(place_name, plc_description) AGAINST (? IN BOOLEAN MODE)", word + "*"
+                                        "MATCH(place_name, plc_description) AGAINST (? IN NATURAL LANGUAGE MODE)", word + "*"
                                 ))
                                 .reduce(DSL.noCondition(), DSL::or)
                 );
@@ -206,7 +207,7 @@ public class SearchJooqRepositoryImpl implements SearchJooqRepository {
                 .where(
                         Arrays.stream(searchWords)
                                 .map(word -> DSL.condition(
-                                        "MATCH(address, province, city_district, subdistrict) AGAINST (? IN BOOLEAN MODE)", word + "*"
+                                        "MATCH(address, province, city_district, subdistrict) AGAINST (? IN NATURAL LANGUAGE MODE)", word + "*"
                                 ))
                                 .reduce(DSL.noCondition(), DSL::or)
                 );

--- a/backend/src/main/java/com/meong9/backend/domain/search/repository/SearchJooqRepositoryImpl.java
+++ b/backend/src/main/java/com/meong9/backend/domain/search/repository/SearchJooqRepositoryImpl.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.jooq.Condition;
 import org.jooq.DSLContext;
 import org.jooq.Field;
+import org.jooq.Table;
 import org.jooq.impl.DSL;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -28,6 +29,18 @@ public class SearchJooqRepositoryImpl implements SearchJooqRepository {
     @Override
     public Slice<SearchPlaceDto> searchPlaces(List<Long> filteredPlaceIds, List<Long> categoryIds, String sizeCode, String typeCode, Long memberId, Pageable pageable) {
 
+        // 1. 1차 필터링된 장소ID에 더해, 2차로 카테고리 필터링, 3차로 무게 필터링을 마친 filted_placesid_field 생성
+        var filteredPlaceSubquery = dsl.select(PLACE.PLACE_ID)
+                .from(PLACE)
+                .where(PLACE.PLC_CATEGORY_ID.in(categoryIds))
+                .and(getWeightCondition(sizeCode))
+                .limit(pageable.getPageSize() + 1)
+                .offset((int) pageable.getOffset())
+                .asTable("filtered_places");
+
+        Field<Long> filteredPlaceIdField = DSL.field("filtered_places.place_id", Long.class);
+
+        // 2. 필터링이 끝난 id를 기반으로 정보를 가져와 dto에 매핑
         List<SearchPlaceDto> places = dsl.select(
                         PLACE.PLACE_ID, // placeId
                         PLACE.PLACE_NAME.as("placeName"), // placeName
@@ -41,27 +54,27 @@ public class SearchJooqRepositoryImpl implements SearchJooqRepository {
                 )
                 .from(PLACE)
                 .join(PLC_CATEGORY).on(PLACE.PLC_CATEGORY_ID.eq(PLC_CATEGORY.PLC_CATEGORY_ID))
-                .where(
-                        PLACE.PLACE_ID.in(filteredPlaceIds)
-                                .and(PLACE.PLC_CATEGORY_ID.in(categoryIds))
-                                .and(getWeightCondition(sizeCode))
-                )
+                .where(PLACE.PLACE_ID.in(
+                        dsl.select(filteredPlaceIdField).from(filteredPlaceSubquery)
+                ))
                 .orderBy(DSL.field("review_count").desc())
-                .limit(pageable.getPageSize())
-                .offset((int)pageable.getOffset())
                 .fetchInto(SearchPlaceDto.class);
 
         // filteredPlaceIds에 해당하는 태그 & 이미지 데이터를 한 번에 조회
         Map<Long, List<String>> tagsByPlaceId = dsl.select(PLACE_TAG.PLACE_ID, TAG.TAG_NAME)
                 .from(PLACE_TAG)
                 .join(TAG).on(PLACE_TAG.TAG_ID.eq(TAG.TAG_ID))
-                .where(PLACE_TAG.PLACE_ID.in(filteredPlaceIds))
+                .where(PLACE_TAG.PLACE_ID.in(
+                        dsl.select(filteredPlaceIdField).from(filteredPlaceSubquery)
+                ))
                 .fetchGroups(PLACE_TAG.PLACE_ID, TAG.TAG_NAME);
 
         Map<Long, List<String>> imagesByPlaceId = dsl.select(PLACE_FILE.PLACE_ID, MEDIA_FILE.FILE_URL)
                 .from(PLACE_FILE)
                 .join(MEDIA_FILE).on(PLACE_FILE.MEDIA_FILE_ID.eq(MEDIA_FILE.MEDIA_FILE_ID))
-                .where(PLACE_FILE.PLACE_ID.in(filteredPlaceIds))
+                .where(PLACE_FILE.PLACE_ID.in(
+                        dsl.select(filteredPlaceIdField).from(filteredPlaceSubquery)
+                ))
                 .fetchGroups(PLACE_FILE.PLACE_ID, MEDIA_FILE.FILE_URL);
 
         // 태그 & 이미지 데이터 매핑
@@ -74,6 +87,9 @@ public class SearchJooqRepositoryImpl implements SearchJooqRepository {
         });
 
         boolean hasNext = places.size() > pageable.getPageSize();
+
+        // slice는 다음에 데이터가 있는지 알 수 없기 때문에, 먼저 11개를 요청한 다음 11개가 들고와지면 10개로 줄여서 보내기
+        if (hasNext) places.remove(places.size() - 1);
 
         return new SliceImpl<>(places, pageable, hasNext);
     }
@@ -158,6 +174,7 @@ public class SearchJooqRepositoryImpl implements SearchJooqRepository {
         List<Long> result = findPlaceIdsBySearchWordInternal(searchWord, pageable);
 
         boolean hasNext = result.size() > pageable.getPageSize();
+        if (hasNext) result.remove(result.size() - 1);
 
         return new SliceImpl<>(result, pageable, hasNext);
     }
@@ -200,7 +217,7 @@ public class SearchJooqRepositoryImpl implements SearchJooqRepository {
 
         // 페이징을 해야 되는 상황에서만 처리하도록
         if (pageable != null) {
-            return combinedQuery.limit(pageable.getPageSize())
+            return combinedQuery.limit(pageable.getPageSize()+1)
                     .offset((int) pageable.getOffset())
                     .fetchInto(Long.class);
         }
@@ -242,47 +259,38 @@ public class SearchJooqRepositoryImpl implements SearchJooqRepository {
                 .fetchInto(Long.class);
 
         boolean hasNext = result.size() > pageable.getPageSize();
+        if (hasNext) result.remove(result.size() - 1);
 
         return new SliceImpl<>(result, pageable, hasNext);
     }
 
     private Field<String> getAddressFieldForPlace(String typeCode) {
-        return dsl.select(ADDRESS.ADDRESS_)
-                .from(PLC_PEN_ADDRESS)
-                .join(ADDRESS).on(PLC_PEN_ADDRESS.ADDRESS_ID.eq(ADDRESS.ADDRESS_ID))
-                .where(PLC_PEN_ADDRESS.PLC_PEN_ID.eq(PLACE.PLACE_ID))
-                .and(PLC_PEN_ADDRESS.TYPE.eq(typeCode))
-                .asField();
+        return getAddressField(PLACE.PLACE_ID, typeCode);
     }
 
     private Field<String> getAddressFieldForPension(String typeCode) {
+        return getAddressField(PENSION.PENSION_ID, typeCode);
+    }
+
+    private Field<String> getAddressField(Field<Long> idField, String typeCode) {
         return dsl.select(ADDRESS.ADDRESS_)
                 .from(PLC_PEN_ADDRESS)
                 .join(ADDRESS).on(PLC_PEN_ADDRESS.ADDRESS_ID.eq(ADDRESS.ADDRESS_ID))
-                .where(PLC_PEN_ADDRESS.PLC_PEN_ID.eq(PENSION.PENSION_ID))
+                .where(PLC_PEN_ADDRESS.PLC_PEN_ID.eq(idField))
                 .and(PLC_PEN_ADDRESS.TYPE.eq(typeCode))
                 .asField();
     }
 
-    private Field<Boolean> getLikeStatusFieldForPlace(Long memberId) {
-        if (memberId == null) {
-            return DSL.inline(false).as("likeStatus");
-        }
 
-        return DSL.when(
-                        DSL.exists(
-                                DSL.selectOne()
-                                        .from(LIKES)
-                                        .where(LIKES.MEMBER_ID.eq(memberId))
-                                        .and(LIKES.PLACE_ID.eq(PLACE.PLACE_ID))
-                        ),
-                        DSL.inline(true)
-                )
-                .otherwise(DSL.inline(false))
-                .as("likeStatus");
+    private Field<Boolean> getLikeStatusFieldForPlace(Long memberId) {
+        return getLikeStatusField(memberId, LIKES.PLACE_ID, PLACE.PLACE_ID);
     }
 
     private Field<Boolean> getLikeStatusFieldForPension(Long memberId) {
+        return getLikeStatusField(memberId, LIKES.PENSION_ID, PENSION.PENSION_ID);
+    }
+
+    private Field<Boolean> getLikeStatusField(Long memberId, Field<Long> idField1, Field<Long> idField2) {
         if (memberId == null) {
             return DSL.inline(false).as("likeStatus");
         }
@@ -292,7 +300,7 @@ public class SearchJooqRepositoryImpl implements SearchJooqRepository {
                                 DSL.selectOne()
                                         .from(LIKES)
                                         .where(LIKES.MEMBER_ID.eq(memberId))
-                                        .and(LIKES.PENSION_ID.eq(PENSION.PENSION_ID))
+                                        .and(idField1.eq(idField2))
                         ),
                         DSL.inline(true)
                 )

--- a/backend/src/main/java/com/meong9/backend/domain/search/repository/SearchJooqRepositoryImpl.java
+++ b/backend/src/main/java/com/meong9/backend/domain/search/repository/SearchJooqRepositoryImpl.java
@@ -26,7 +26,7 @@ public class SearchJooqRepositoryImpl implements SearchJooqRepository {
     private final DSLContext dsl;
 
     @Override
-    public List<SearchPlaceDto> searchPlaces(List<Long> filteredPlaceIds, List<Long> categoryIds, String sizeCode, String typeCode, Long memberId) {
+    public Slice<SearchPlaceDto> searchPlaces(List<Long> filteredPlaceIds, List<Long> categoryIds, String sizeCode, String typeCode, Long memberId, Pageable pageable) {
 
         List<SearchPlaceDto> places = dsl.select(
                         PLACE.PLACE_ID, // placeId
@@ -47,6 +47,8 @@ public class SearchJooqRepositoryImpl implements SearchJooqRepository {
                                 .and(getWeightCondition(sizeCode))
                 )
                 .orderBy(DSL.field("review_count").desc())
+                .limit(pageable.getPageSize())
+                .offset((int)pageable.getOffset())
                 .fetchInto(SearchPlaceDto.class);
 
         // filteredPlaceIds에 해당하는 태그 & 이미지 데이터를 한 번에 조회
@@ -71,7 +73,9 @@ public class SearchJooqRepositoryImpl implements SearchJooqRepository {
             place.setImages(images);
         });
 
-        return places;
+        boolean hasNext = places.size() > pageable.getPageSize();
+
+        return new SliceImpl<>(places, pageable, hasNext);
     }
 
     @Override
@@ -150,8 +154,21 @@ public class SearchJooqRepositoryImpl implements SearchJooqRepository {
     }
 
     @Override
-    public Slice<Long> findPlaceIdsBySearchWord(String searchWord, Pageable pageable) {
-        // 검색어를 단어별로 나누어 배열에 담기
+    public Slice<Long> findPlaceIdsBySearchWordForMap(String searchWord, Pageable pageable) {
+        List<Long> result = findPlaceIdsBySearchWordInternal(searchWord, pageable);
+
+        boolean hasNext = result.size() > pageable.getPageSize();
+
+        return new SliceImpl<>(result, pageable, hasNext);
+    }
+
+    @Override
+    public List<Long> findPlaceIdsBySearchWord(String searchWord) {
+        return findPlaceIdsBySearchWordInternal(searchWord, null);
+    }
+
+    private List<Long> findPlaceIdsBySearchWordInternal(String searchWord, Pageable pageable) {
+        // 검색어를 단어별로 나누기
         String[] searchWords = searchWord.split(" ");
 
         // place 테이블에서 검색
@@ -177,16 +194,18 @@ public class SearchJooqRepositoryImpl implements SearchJooqRepository {
                                 .reduce(DSL.noCondition(), DSL::or)
                 );
 
-        // 두 결과를 UNION으로 합치기
-        List<Long> result =  dsl.selectDistinct(DSL.field("place_id", Long.class))
-                .from(placeQuery.union(addressQuery).asTable("combined_results"))
-                .limit(pageable.getPageSize())
-                .offset((int) pageable.getOffset())
-                .fetchInto(Long.class);
+        // UNION으로 검색 결과 합치기
+        var combinedQuery = dsl.selectDistinct(DSL.field("place_id", Long.class))
+                .from(placeQuery.union(addressQuery).asTable("combined_results"));
 
-        boolean hasNext = result.size() > pageable.getPageSize();
+        // 페이징을 해야 되는 상황에서만 처리하도록
+        if (pageable != null) {
+            return combinedQuery.limit(pageable.getPageSize())
+                    .offset((int) pageable.getOffset())
+                    .fetchInto(Long.class);
+        }
 
-        return new SliceImpl<>(result, pageable, hasNext);
+        return combinedQuery.fetchInto(Long.class);
     }
 
     @Override
@@ -226,7 +245,6 @@ public class SearchJooqRepositoryImpl implements SearchJooqRepository {
 
         return new SliceImpl<>(result, pageable, hasNext);
     }
-
 
     private Field<String> getAddressFieldForPlace(String typeCode) {
         return dsl.select(ADDRESS.ADDRESS_)

--- a/backend/src/main/java/com/meong9/backend/domain/search/service/SearchService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/search/service/SearchService.java
@@ -50,18 +50,18 @@ public class SearchService {
                                                 double heaviestDogWeight, Pageable pageable, Long memberId) {
         String typeCode = "010"; // 시설 코드
 
-        Slice<Long> filteredPlaceIds; // 최종 필터링된 시설 ID 목록
+        List<Long> filteredPlaceIds; // 최종 필터링된 시설 ID 목록
 
         if (searchWord != null && !searchWord.trim().isEmpty()) {
             // 1. 검색어로 시설 ID 필터링
-            filteredPlaceIds = searchRepository.findPlaceIdsBySearchWord(searchWord, pageable);
+            filteredPlaceIds = searchRepository.findPlaceIdsBySearchWord(searchWord);
         } else {
             // 2. 지역으로 시설 ID 필터링
             List<Long> regionIds = (regionList == null || regionList.isEmpty())
                     ? regionRepository.findAllRegionIds()
                     : regionRepository.findRegionIdsByNameIn(regionList);
 
-            filteredPlaceIds = plcPenAddressRepository.findFacilityIdsByRegionIdIn(regionIds, typeCode, pageable);
+            filteredPlaceIds = plcPenAddressRepository.findFacilityIdsByRegionIdIn(regionIds, typeCode);
         }
 
         List<Long> categoryIds = (placeTypes == null || placeTypes.isEmpty())
@@ -72,16 +72,17 @@ public class SearchService {
         String sizeCode = heaviestDogWeight < 10 ? "010" : heaviestDogWeight < 25 ? "020" : "030";
 
         // 3. 최종 필터링된 시설 조회
-        List<SearchPlaceDto> filteredPlaces =
+        Slice<SearchPlaceDto> filteredPlaces =
                 searchRepository.searchPlaces(
-                filteredPlaceIds.getContent(),
+                filteredPlaceIds,
                 categoryIds,
                 sizeCode,
                 typeCode,
-                memberId);
+                memberId,
+                pageable);
 
         // 4. 반환
-        return new SearchPlacesResponseDto(filteredPlaces, filteredPlaceIds.hasNext());
+        return new SearchPlacesResponseDto(filteredPlaces.getContent(), filteredPlaces.hasNext());
     }
 
     @Transactional(readOnly = true)
@@ -101,7 +102,7 @@ public class SearchService {
                     ? regionRepository.findAllRegionIds()
                     : regionRepository.findRegionIdsByNameIn(regionList);
 
-            filteredPensionIds = plcPenAddressRepository.findFacilityIdsByRegionIdIn(regionIds, typeCode, pageable);
+            filteredPensionIds = plcPenAddressRepository.findFacilityIdsByRegionIdInWithPagination(regionIds, typeCode, pageable);
         }
 
         // 2. 반려견 체중 조건 추가


### PR DESCRIPTION
## 📋 Summary
<!-- 이 PR에서 변경된 주요 내용을 간략히 작성해주세요. -->
- 검색 재리팩토링 
- 검색 boolean mode -> natural language mode로 변경
- room file id -> equals and hashcode 어노테이션 추가
- member service -> transactional 어노테이션 상세 분류

## ✨ Feature Details
| Method | Path                      | Description      |
|--------|---------------------------|------------------|


## 💡 Key Considerations
<!-- 구현하면서 고려한 점, 또는 해결한 주요 이슈를 간단히 작성해주세요. -->
1. 검색 카테고리 필터링 적용 시 아무 검색 결과도 나오지 않는다는 문제가 있었음. 
- 검색은 1차 검색어 및 지역 필터링 - 2차 카테고리 필터링 으로 나누어져 있음. 
- 페이징 시점을 1차에서 2차로 옮겨 이슈 해결. 
- 지도에서 해당 1차 검색을 같이 쓰고 있기 때문에, 페이징 처리가 필요한 지도 검색은 메서드를 분리함. 
- 더불어 장소/펜션 검색의 중복 코드를 추출하여 동적으로 활용할 수 있게 리팩토링함. 
- boolean mode 보다는 토큰 사이즈로 파싱하여 풀텍스트 서치를 진행할 수 있는 natural language mode로 변경. 
- 자연어 검색 수행 후 검색에 매칭된 행을 기반으로 검색 문자열을 재구성하여 두 번째 검색을 수행하는 with query expansion 설정까지 검토해 보았으나 검색 결과 정확도가 떨어진다고 판단되어 적용하지 않음. 

2. hasNext 수정
- slice는 뒤에 내용이 더 있는지 없는지 알 수 없기 때문에, 조건된 사이즈보다 1개를 더 가져오는 것으로 hasNext flag를 판단하도록 수정. 
- 1개가 더 가져와지면 true로 판단하고 이후 1개는 검색 결과에서 제외하는 것으로 사이즈를 맞춤. 

## ✅ Checklist
- [X] 코드를 스스로 검토했나요?
- [X] 필요한 테스트를 추가하고 모두 통과했나요?
- [X] 브랜치 전략에 맞는 브랜치에 PR을 올렸나요?
- [X] 커밋 메시지가 컨벤션에 맞나요?
- [X] 필요한 문서를 업데이트했나요?
