### PR TITLE
From Kan 96 be feat/recommendation default into dev : 로그인 되지 않은 사용자 기본 추천

### DIFF
--- a/backend/src/main/java/com/meong9/backend/domain/like/repository/LikeRepository.java
+++ b/backend/src/main/java/com/meong9/backend/domain/like/repository/LikeRepository.java
@@ -84,4 +84,13 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
 
 
 
+    // 좋아요를 많이 받은 순 펜션 목록
+    @Query("""
+        SELECT p.pensionId
+        FROM PensionLike pl
+        JOIN pl.pension p
+        GROUP BY p.pensionId
+        ORDER BY COUNT(pl) DESC
+    """)
+    Page<Long> findTopPensionIds(Pageable pageable);
 }

--- a/backend/src/main/java/com/meong9/backend/domain/like/service/LikeService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/like/service/LikeService.java
@@ -1,5 +1,7 @@
 package com.meong9.backend.domain.like.service;
 
+import com.meong9.backend.domain.address.entity.PlcPenAddress;
+import com.meong9.backend.domain.address.repository.PlcPenAddressRepository;
 import com.meong9.backend.domain.like.entity.PensionLike;
 import com.meong9.backend.domain.like.entity.PlaceLike;
 import com.meong9.backend.domain.like.repository.LikeRepository;
@@ -8,10 +10,20 @@ import com.meong9.backend.domain.pension.entity.Pension;
 import com.meong9.backend.domain.pension.repository.PensionRepository;
 import com.meong9.backend.domain.place.entity.Place;
 import com.meong9.backend.domain.place.repository.PlaceRepository;
+import com.meong9.backend.domain.recommendation.recommendation.dto.RecommendationDto;
 import com.meong9.backend.global.exception.NotFoundException;
+import com.meong9.backend.global.utils.AddressMapper;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Page;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -19,6 +31,7 @@ public class LikeService {
     private final LikeRepository likeRepository;
     private final PlaceRepository placeRepository;
     private final PensionRepository pensionRepository;
+    private final PlcPenAddressRepository plcPenAddressRepository;
 
     @Transactional
     public String togglePlaceLike(Member member, Long placeId) {
@@ -65,4 +78,34 @@ public class LikeService {
     public boolean isPensionLikedByMember(Member member, Long pensionId) {
         return likeRepository.existsByMemberAndPensionId(member, pensionId);
     }
+
+    // 좋아요 가장 많은 펜션
+    public List<RecommendationDto> getTopLikedPensions() {
+        PageRequest pageRequest = PageRequest.of(0, 5);
+
+        // 좋아요가 많은 펜션 ID 가져오기
+        Page<Long> pensionIdPage = likeRepository.findTopPensionIds(pageRequest);
+        List<Long> pensionIdList = pensionIdPage.getContent();
+
+        // 펜션 및 주소 가져오기
+        List<Pension> pensions = pensionRepository.findAllDataByIds(pensionIdList);
+        List<PlcPenAddress> plcPenAddresses = plcPenAddressRepository.findAddressesByIdsAndType(pensionIdList, "020");
+
+        // 주소 매핑
+        Map<Long, String> addressMap = plcPenAddresses.stream()
+                .collect(Collectors.toMap(
+                        PlcPenAddress::getPlcPenId, // 장소 ID를 키로 사용
+                        AddressMapper::formatAddress
+                ));
+
+        // RecommendationDto 생성
+        List<RecommendationDto> recommendationDtos = new ArrayList<>();
+        for (Pension pension : pensions) {
+            String formattedAddress = addressMap.get(pension.getPensionId());
+            recommendationDtos.add(RecommendationDto.createdRecommendationDto(pension, formattedAddress));
+        }
+
+        return recommendationDtos;
+    }
+
 }

--- a/backend/src/main/java/com/meong9/backend/domain/like/service/LikeService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/like/service/LikeService.java
@@ -87,6 +87,10 @@ public class LikeService {
         Page<Long> pensionIdPage = likeRepository.findTopPensionIds(pageRequest);
         List<Long> pensionIdList = pensionIdPage.getContent();
 
+        if (pensionIdList.isEmpty()) {
+            throw NotFoundException.entityNotFound("추천된 펜션");
+        }
+
         // 펜션 및 주소 가져오기
         List<Pension> pensions = pensionRepository.findAllDataByIds(pensionIdList);
         List<PlcPenAddress> plcPenAddresses = plcPenAddressRepository.findAddressesByIdsAndType(pensionIdList, "020");

--- a/backend/src/main/java/com/meong9/backend/domain/recommendation/recommendation/controller/RecommendationController.java
+++ b/backend/src/main/java/com/meong9/backend/domain/recommendation/recommendation/controller/RecommendationController.java
@@ -1,5 +1,6 @@
 package com.meong9.backend.domain.recommendation.recommendation.controller;
 
+import com.meong9.backend.domain.like.service.LikeService;
 import com.meong9.backend.domain.member.entity.Member;
 import com.meong9.backend.domain.recommendation.recommendation.dto.RecommendationDto;
 import com.meong9.backend.domain.recommendation.recommendation.entity.PensionRecommendation;
@@ -22,14 +23,20 @@ import java.util.Map;
 public class RecommendationController {
 
     private final RecommendationService recommendationService;
+    private final LikeService likeService;
 
     @GetMapping("/spots/recommendations")
     public ResponseEntity<?> recommendPensions(@CurrentMember Member member) {
-        List<RecommendationDto> recommendItem = recommendationService.getPensionRecommendations(member, 5);
-
         Map<String, List<RecommendationDto>> recommend = new HashMap<>();
-        recommend.put("recommend", recommendItem);
 
+        if(member == null) { // 로그인 되지 않은 사용자
+            // 좋아요 인기 펜션
+            List<RecommendationDto> recommendItem = likeService.getTopLikedPensions();
+            recommend.put("recommend", recommendItem);
+        } else { // 로그인 된 사용자
+            List<RecommendationDto> recommendItem = recommendationService.getPensionRecommendations(member, 5);
+            recommend.put("recommend", recommendItem);
+        }
         return CommonResponse.ok("success", recommend);
     }
 

--- a/backend/src/main/java/com/meong9/backend/domain/recommendation/recommendation/dto/RecommendationDto.java
+++ b/backend/src/main/java/com/meong9/backend/domain/recommendation/recommendation/dto/RecommendationDto.java
@@ -1,5 +1,6 @@
 package com.meong9.backend.domain.recommendation.recommendation.dto;
 
+import com.meong9.backend.domain.pension.entity.Pension;
 import lombok.*;
 
 @Getter
@@ -14,4 +15,22 @@ public class RecommendationDto {
     private String img;
     private String reviewAvg;
     private Integer reviewCount;
+
+    public static RecommendationDto createdRecommendationDto(Pension pension, String address){
+        String img = null;
+
+        if(pension.getPensionFiles().size() > 0){
+            img = pension.getPensionFiles().get(0).getMediaFile().getFileUrl();
+        }
+
+        return RecommendationDto.builder()
+                .id(pension.getPensionId())
+                .name(pension.getName())
+                .address(address)
+                .img(img)
+                .reviewAvg(pension.getReviewAvg().toString())
+                .reviewCount(pension.getReviewCount())
+                .build();
+
+    }
 }

--- a/backend/src/main/java/com/meong9/backend/domain/recommendation/recommendation/service/RecommendationService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/recommendation/recommendation/service/RecommendationService.java
@@ -13,6 +13,7 @@ import com.meong9.backend.domain.recommendation.recommendation.repository.Pensio
 import com.meong9.backend.domain.recommendation.recommendation.repository.PlaceRecommendationRepository;
 import com.meong9.backend.domain.review.repository.ReviewRepository;
 import com.meong9.backend.global.exception.NotFoundException;
+import com.meong9.backend.global.utils.AddressMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.mahout.cf.taste.impl.model.jdbc.ReloadFromJDBCDataModel;
 import org.apache.mahout.cf.taste.model.DataModel;
@@ -123,7 +124,7 @@ public class RecommendationService {
             PlcPenAddress plcPenAddress= plcPenAddressRepository.findByPlcPenIdAndType(pensionRecommendation.getPensionMemberId().getPensionId(), "020")
                     .orElseThrow(() -> NotFoundException.entityNotFound("시설 주소"));
 
-            String address = plcPenAddress.getAddress().getProvince() + " " + plcPenAddress.getAddress().getCityDistrict();
+            String address = AddressMapper.formatAddress(plcPenAddress);
 
             // 이미지 null 체크
             String img = null;

--- a/backend/src/main/java/com/meong9/backend/global/auth/filter/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/meong9/backend/global/auth/filter/JwtAuthenticationFilter.java
@@ -47,6 +47,29 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                     filterChain.doFilter(req, res);
                     return;
                 }
+
+                // Authorization 헤더가 있지만 잘못된 토큰일 경우 익명 사용자로 처리
+                String tokenValue = jwtProvider.getTokenFromRequest(req, JwtProvider.AUTHORIZATION_HEADER);
+                if (!StringUtils.hasText(tokenValue)) {
+                    filterChain.doFilter(req, res);
+                    return;
+                }
+
+                try {
+                    jwtProvider.validateToken(tokenValue);
+
+                    String username = jwtProvider.getSubjectFromToken(tokenValue);
+                    UserDetails userDetails = detailsService.loadUserByUsername(username);
+                    validateUserRole(userDetails, jwtProvider.getRoleFromToken(tokenValue));
+                    setAuthentication(userDetails);
+                } catch (Exception e) {
+                    // 잘못된 토큰인 경우 SecurityContext 초기화 후 요청을 계속 처리
+                    SecurityContextHolder.clearContext();
+                    log.warn("토큰이 유효하지 않습니다.");
+                }
+
+                filterChain.doFilter(req, res);
+                return;
             }
 
             // 3. Access Token 인증 처리

--- a/backend/src/main/java/com/meong9/backend/global/utils/AddressMapper.java
+++ b/backend/src/main/java/com/meong9/backend/global/utils/AddressMapper.java
@@ -26,6 +26,9 @@ public class AddressMapper {
         }
 
         if(cityDistrict == null || cityDistrict.isBlank()) {
+            if(subDistrict == null || subDistrict.isBlank()) {
+                return province;
+            }
             subDistrict = subDistrict.substring(0, Math.min(2, subDistrict.length()));
             return province + " " + subDistrict;
         } else {

--- a/backend/src/main/java/com/meong9/backend/global/utils/AddressMapper.java
+++ b/backend/src/main/java/com/meong9/backend/global/utils/AddressMapper.java
@@ -15,6 +15,7 @@ public class AddressMapper {
 
         String province = plcPenAddress.getAddress().getProvince();
         String cityDistrict = plcPenAddress.getAddress().getCityDistrict();
+        String subDistrict = plcPenAddress.getAddress().getSubDistrict();
 
         // Province가 4글자일 때 1번째, 3번째 추출 -> 충청남도 -> 충남
         if (province.length() == 4) {
@@ -23,9 +24,14 @@ public class AddressMapper {
             // 그 외의 경우 앞 두 글자만 추출
             province = province.substring(0, Math.min(2, province.length()));
         }
-        cityDistrict = cityDistrict.substring(0, Math.min(2, cityDistrict.length()));
 
-        return province + " " + cityDistrict;
+        if(cityDistrict == null || cityDistrict.isBlank()) {
+            subDistrict = subDistrict.substring(0, Math.min(2, subDistrict.length()));
+            return province + " " + subDistrict;
+        } else {
+            cityDistrict = cityDistrict.substring(0, Math.min(2, cityDistrict.length()));
+            return province + " " + cityDistrict;
+        }
     }
 
     // 주소 정보 담는 Map


### PR DESCRIPTION
## 📋 Summary
<!-- 이 PR에서 변경된 주요 내용을 간략히 작성해주세요. -->
1. 로그인 되지 않은 사용자의 경우 좋아요 순 상위 5개의 펜션 반환
2. Authorization 헤더가 있지만 잘못된 토큰일 경우 익명 사용자로 처리 (/api/v1/search, /api/v1/spots/recommendations)
    _(search랑 security 엮여있어서 신지언니 확인 필요)_

## ✨ Feature Details
| Method | Path                      | Description      |
|--------|---------------------------|------------------|
| GET | /api/v1/spots/recommendations | 펜션 추천 조회  |


## 💡 Key Considerations
<!-- 구현하면서 고려한 점, 또는 해결한 주요 이슈를 간단히 작성해주세요. -->
기존에 Authorization 헤더가 없을 때만 익명 사용자로 됐어서 잘못된 토큰으로 인증이 안된 경우 401이 떴음. 
그래서 /api/v1/search랑 /api/v1/spots/recommendations 부분 헤더가 있지만 잘못된 토큰일 경우 익명 사용자로 처리하는 코드를 추가함 
AddressMapper에서 시/구(cityDistrict)가 없는 경우에 읍면리(subDistrict)를 사용해서 주소 반환하도록 수정 (ex. 세종 연동) 
![image](https://github.com/user-attachments/assets/8a790d31-9e7f-4f30-abf7-38f7701145aa)


## ✅ Checklist
- [x] 코드를 스스로 검토했나요?
- [x] 필요한 테스트를 추가하고 모두 통과했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올렸나요?
- [x] 커밋 메시지가 컨벤션에 맞나요?
- [x] 필요한 문서를 업데이트했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- 가장 많이 좋아요를 받은 연금 목록을 가져오는 기능 추가.
	- 추천 연금 DTO 생성 기능 추가.
- **버그 수정**
	- 토큰 검증 로직 개선으로 잘못된 토큰 처리 강화.
- **문서화**
	- 주소 포맷팅 로직 개선으로 주소 처리 모듈화.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->