### PR TITLE
From refactorMeongPhoto into dev : 멍생네컷 S3 에러 시 응답 수정 

### DIFF
--- a/backend/src/main/java/com/meong9/backend/domain/meongPhoto/dto/MeongPhotoResponseDto.java
+++ b/backend/src/main/java/com/meong9/backend/domain/meongPhoto/dto/MeongPhotoResponseDto.java
@@ -9,4 +9,5 @@ public class MeongPhotoResponseDto {
 
     private final String imageUrl;
     private final String imageDownloadUrl;
+    private final boolean isProcessing;
 }

--- a/backend/src/main/java/com/meong9/backend/domain/meongPhoto/service/MeongPhotoService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/meongPhoto/service/MeongPhotoService.java
@@ -51,11 +51,11 @@ public class MeongPhotoService {
             MeongPhoto meongPhoto = MeongPhoto.createMeongPhoto(member, savedMeongPhoto);
             meongPhotoRepository.save(meongPhoto);
 
-            return new MeongPhotoResponseDto(s3UploadResultDto.getS3Url(), downloadImageUrl);
+            return new MeongPhotoResponseDto(s3UploadResultDto.getS3Url(), downloadImageUrl, false);
         } catch (IOException e) {
             log.error("멍생네컷 저장 중 오류 발생: {}", e.getMessage(), e);
             tempFileService.saveTemporaryFile(serviceUrl, file, member.getMemberId(), "MEMBER");
-            throw InternalServerError.photoProcessingError();
+            return new MeongPhotoResponseDto(null, null, true);
         }
     }
 

--- a/backend/src/main/java/com/meong9/backend/domain/meongPhoto/service/MeongPhotoService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/meongPhoto/service/MeongPhotoService.java
@@ -4,7 +4,6 @@ import com.meong9.backend.domain.member.entity.Member;
 import com.meong9.backend.domain.meongPhoto.dto.*;
 import com.meong9.backend.domain.meongPhoto.entity.MeongPhoto;
 import com.meong9.backend.domain.meongPhoto.repository.MeongPhotoRepository;
-import com.meong9.backend.global.exception.InternalServerError;
 import com.meong9.backend.global.mediafile.dto.ImageMetadataDto;
 import com.meong9.backend.global.mediafile.dto.S3UploadResultDto;
 import com.meong9.backend.global.mediafile.entity.MediaFile;


### PR DESCRIPTION
## 📋 Summary
<!-- 이 PR에서 변경된 주요 내용을 간략히 작성해주세요. -->
- s3 오류가 나도 프론트에 200을 반환. 
- 다만 isProcessing 이라는 flag를 두어 프론트에서 오류 여부를 확인할 수 있도록 함. 
- isProcessing이 true일 경우 프론트에서 다운로드 진행하도록 함. 

## ✨ Feature Details
| Method | Path                      | Description      |
|--------|---------------------------|------------------|


## 💡 Key Considerations
<!-- 구현하면서 고려한 점, 또는 해결한 주요 이슈를 간단히 작성해주세요. -->


## ✅ Checklist
- [ ] 코드를 스스로 검토했나요?
- [ ] 필요한 테스트를 추가하고 모두 통과했나요?
- [ ] 브랜치 전략에 맞는 브랜치에 PR을 올렸나요?
- [ ] 커밋 메시지가 컨벤션에 맞나요?
- [ ] 필요한 문서를 업데이트했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 사진 응답에 대한 처리 상태를 나타내는 `isProcessing` 필드 추가.
  - 사진 생성 메서드가 성공 또는 실패 상태를 구조화된 응답으로 반환하도록 변경.

- **버그 수정**
  - 오류 발생 시 `InternalServerError` 예외 대신 상태를 나타내는 응답 반환.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->