### PR TITLE
From KAN-106-BE-feat/imageResize into dev : 로그인 Url 복구 및 mediaFileService.getPresignedUrl() 추가

### DIFF
--- a/backend/src/main/java/com/meong9/backend/global/mediafile/service/MediaFileService.java
+++ b/backend/src/main/java/com/meong9/backend/global/mediafile/service/MediaFileService.java
@@ -1,6 +1,7 @@
 package com.meong9.backend.global.mediafile.service;
 
 import com.amazonaws.HttpMethod;
+import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
@@ -12,7 +13,6 @@ import com.meong9.backend.global.mediafile.entity.FileType;
 import com.meong9.backend.global.mediafile.entity.MediaFile;
 import com.meong9.backend.global.mediafile.repository.MediaFileRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
@@ -28,8 +28,12 @@ import java.net.URL;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
-import java.util.concurrent.*;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 @Service
 @RequiredArgsConstructor
@@ -37,12 +41,17 @@ public class MediaFileService {
 
     private final AmazonS3Client s3Client;
     private final MediaFileRepository mediaFileRepository;
+    private final AmazonS3 amazonS3;
+
     @Qualifier("taskExecutor")
     private final ThreadPoolTaskExecutor taskExecutor;
 
-
     @Value("${s3.bucket}")
     private String bucket;
+
+    @Value("${s3.credentials.region}")
+    private String region;
+
 
     /**
      * 유저가 등록한 프로필 이미지를 S3에 업로드
@@ -348,4 +357,32 @@ public class MediaFileService {
         );
     }
 
+    public MediaFile registerFileKey(String fileKey) {
+
+        String fileUrl = String.format("https://%s.s3.%s.amazonaws.com/%s", bucket, region, fileKey);
+
+        return MediaFile.builder()
+                .fileType(FileType.IMAGE)
+                .fileKey(fileKey)
+                .fileName("profile.jpg")
+                .fileUrl(fileUrl)
+                .build();
+    }
+
+
+    public Map<String, String> getPresingedUrl(String objectKey) {
+        // PreSigned URL 생성
+        Date expiration = new Date(System.currentTimeMillis() + 1000 * 60 * 10); // 10분 유효
+        GeneratePresignedUrlRequest request = new GeneratePresignedUrlRequest(bucket, objectKey)
+                .withMethod(HttpMethod.PUT)
+                .withExpiration(expiration);
+
+        String presignedUrl = amazonS3.generatePresignedUrl(request).toString();
+
+        // PreSigned URL과 파일 경로 반환
+        Map<String, String> response = new HashMap<>();
+        response.put("presignedUrl", presignedUrl);
+        response.put("fileKey", objectKey); // 파일 경로
+        return response;
+    }
 }

--- a/backend/src/main/resources/application-aws.yml
+++ b/backend/src/main/resources/application-aws.yml
@@ -37,7 +37,7 @@ s3:
 
 kakao:
   client-id: ${KAKAO_REST_API_KEY}
-  redirect-uri: https://mungtivity.vercel.app/login
+  redirect-uri: http://localhost:5173/login
   client-secret: ${KAKAO_CLIENT_SECRET}
 
 jwt:


### PR DESCRIPTION
## 📋 Summary
<!-- 이 PR에서 변경된 주요 내용을 간략히 작성해주세요. -->
- 로그인 Url 복구 및 mediaFileService.getPresignedUrl() 추가

## ✨ Feature Details
| Method | Path                      | Description      |
|--------|---------------------------|------------------|


## 💡 Key Considerations
<!-- 구현하면서 고려한 점, 또는 해결한 주요 이슈를 간단히 작성해주세요. -->


## ✅ Checklist
- [ ] 코드를 스스로 검토했나요?
- [ ] 필요한 테스트를 추가하고 모두 통과했나요?
- [ ] 브랜치 전략에 맞는 브랜치에 PR을 올렸나요?
- [ ] 커밋 메시지가 컨벤션에 맞나요?
- [ ] 필요한 문서를 업데이트했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- S3 URL 생성을 위한 `registerFileKey` 메서드 추가.
	- 파일 업로드를 위한 사전 서명된 URL을 생성하는 `getPresingedUrl` 메서드 추가.
- **구성 변경**
	- `redirect-uri` 값을 프로덕션 URL에서 로컬 개발 URL로 변경.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->