### PR TITLE
From KAN-106-BE-feat/imageResize into dev : 장소펜션 상세조회 관련 시큐리티 수정 + 프로필 이미지 등록 presignedUrl 사용

### DIFF
--- a/backend/src/main/java/com/meong9/backend/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/meong9/backend/domain/member/controller/MemberController.java
@@ -5,13 +5,14 @@ import com.meong9.backend.domain.member.entity.Member;
 import com.meong9.backend.domain.member.service.MemberService;
 import com.meong9.backend.global.annotation.member.CurrentMember;
 import com.meong9.backend.global.dto.CommonResponse;
+import com.meong9.backend.global.mediafile.service.MediaFileService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/v1/members")
@@ -19,6 +20,7 @@ import java.io.IOException;
 public class MemberController {
 
     private final MemberService memberService;
+    private final MediaFileService mediaFileService;
 
     /**
      * 회원 선호시설 추가 컨트롤러
@@ -44,10 +46,10 @@ public class MemberController {
      * 회원 정보 등록 요청 컨트롤러
      */
     @PostMapping("/info")
-    public ResponseEntity<?> insertMemberInfo(@RequestPart(name = "ProfileImage", required = false) MultipartFile profileImage,
-                                              @Valid @RequestPart(name = "MemberInfoDto") MemberInfoDto dto,
+    public ResponseEntity<?> insertMemberInfo(@RequestParam(required = false) String fileKey,
+                                              @RequestBody MemberInfoDto dto,
                                               @CurrentMember Member member) throws IOException {
-        memberService.insertMemberInfo(profileImage, dto, member);
+        memberService.insertMemberInfo(fileKey, dto, member);
         return CommonResponse.ok("success");
     }
 
@@ -92,10 +94,10 @@ public class MemberController {
      * 마이페이지 수정 컨트롤러
      */
     @PatchMapping
-    public ResponseEntity<?> updateMyPage(@RequestPart(name = "ProfileImage", required = false) MultipartFile profileImage,
-                                          @Valid @RequestPart(name = "UpdateMyPageRequestDto") MemberInfoDto requestDto,
+    public ResponseEntity<?> updateMyPage(@RequestParam(required = false) String fileKey,
+                                          @Valid @RequestBody MemberInfoDto requestDto,
                                           @CurrentMember Member member) throws IOException {
-        UpdateMyPageResponseDto dto = memberService.updateMyPage(profileImage, requestDto, member);
+        UpdateMyPageResponseDto dto = memberService.updateMyPage(fileKey, requestDto, member);
         return CommonResponse.ok("success", dto);
     }
 
@@ -136,4 +138,19 @@ public class MemberController {
         memberService.insertPreferredPlaces(interestDto, member);
         return CommonResponse.ok("success");
     }
+
+    /**
+     * 프로필 이미지 생성을 위한 PreSigned URL 생성
+     */
+    @GetMapping("/presigned-url")
+    public ResponseEntity<?> generatePreSignedUrlForMProfileImage(@CurrentMember Member member) {
+        // S3 경로 생성: {folder}/{memberId}_profile.jpg
+        String folder = "Mprofile";
+        String objectKey = String.format("%s/%d_profile.jpg", folder, member.getMemberId());
+
+        Map<String, String> response = mediaFileService.getPresingedUrl(objectKey);
+
+        return CommonResponse.ok("success", response);
+    }
+
 }

--- a/backend/src/main/java/com/meong9/backend/domain/member/service/MemberService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/member/service/MemberService.java
@@ -11,19 +11,18 @@ import com.meong9.backend.domain.place.entity.PlcCategory;
 import com.meong9.backend.domain.place.repository.PlcCategoryRepository;
 import com.meong9.backend.domain.puppy.entity.Puppy;
 import com.meong9.backend.domain.puppy.repository.PuppyRepository;
+import com.meong9.backend.global.auth.jwt.JwtProvider;
 import com.meong9.backend.global.auth.refreshtoken.RefreshToken;
 import com.meong9.backend.global.auth.refreshtoken.RefreshTokenService;
-import com.meong9.backend.global.auth.jwt.JwtProvider;
 import com.meong9.backend.global.entity.Region;
 import com.meong9.backend.global.exception.AuthenticationException;
 import com.meong9.backend.global.exception.NotFoundException;
 import com.meong9.backend.global.mediafile.service.MediaFileService;
 import com.meong9.backend.global.repository.RegionRepository;
-import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
 import java.util.List;
@@ -133,8 +132,8 @@ public class MemberService {
      * 사용자 정보를 등록하는 서비스 메서드
      */
     @Transactional
-    public void insertMemberInfo(MultipartFile profileImage,MemberInfoDto dto, Member member) throws IOException {
-        updateMember(profileImage, dto, member);
+    public void insertMemberInfo(String fileKey,MemberInfoDto dto, Member member) throws IOException {
+        updateMember(fileKey, dto, member);
 
         memberRepository.save(member);
     }
@@ -196,8 +195,8 @@ public class MemberService {
      * 마이페이지 수정 메서드
      */
     @Transactional
-    public UpdateMyPageResponseDto updateMyPage(MultipartFile profileImage, MemberInfoDto dto, Member member) throws IOException {
-        updateMember(profileImage, dto, member);
+    public UpdateMyPageResponseDto updateMyPage(String fileKey, MemberInfoDto dto, Member member) throws IOException {
+        updateMember(fileKey, dto, member);
 
         Member savedMember = memberRepository.save(member);
         return UpdateMyPageResponseDto.builder()
@@ -208,14 +207,11 @@ public class MemberService {
                 .build();
     }
 
-    private void updateMember(MultipartFile profileImage, MemberInfoDto dto, Member member) throws IOException {
+    private void updateMember(String fileKey, MemberInfoDto dto, Member member) throws IOException {
         member.setName(dto.getName().trim());
         member.setPhone(dto.getPhone().trim());
         member.setNickname(dto.getNickname().trim());
-
-        if (profileImage != null) {
-            mediaFileService.uploadProfileImage(profileImage, member.getMemberId(),"Mprofile/","_profile.jpg");
-        }
+        member.setProfileImage(mediaFileService.registerFileKey(fileKey));
     }
 
     /**

--- a/backend/src/main/java/com/meong9/backend/domain/puppy/repository/PuppyRepository.java
+++ b/backend/src/main/java/com/meong9/backend/domain/puppy/repository/PuppyRepository.java
@@ -27,6 +27,6 @@ public interface PuppyRepository extends JpaRepository<Puppy, Long> {
             "WHERE p.puppyId = :puppyId")
     Optional<PuppyProfileResponseDto> findPuppyProfileById(@Param("puppyId") Long puppyId);
 
-    @Query("SELECT p FROM Puppy p JOIN FETCH p.profileImage WHERE p.member.memberId = :memberId ORDER BY p.puppyId")
+    @Query("SELECT p FROM Puppy p LEFT JOIN FETCH p.profileImage WHERE p.member.memberId = :memberId ORDER BY p.puppyId")
     List<Puppy> findByMemberIdWithPuppyProfileImage(Long memberId);
 }

--- a/backend/src/main/java/com/meong9/backend/global/auth/filter/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/meong9/backend/global/auth/filter/JwtAuthenticationFilter.java
@@ -13,11 +13,14 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.util.matcher.OrRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.List;
 
 @RequiredArgsConstructor
 @Slf4j(topic = "JwtAuthenticationFilter")
@@ -26,6 +29,16 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtProvider jwtProvider;
     private final UserDetailsService detailsService;
     private final RequestMatcher ignoredRequests;
+    private final RequestMatcher publicUrls = new OrRequestMatcher(
+            List.of(
+                    new AntPathRequestMatcher("/api/v1/search"),
+                    new AntPathRequestMatcher("/api/v1/spots/recommendations"),
+                    new AntPathRequestMatcher("/api/v1/pensions/detail/{pensionId}"),
+                    new AntPathRequestMatcher("/api/v1/places/detail/{placeId}"),
+                    new AntPathRequestMatcher("/api/v1/map/search")
+            )
+    );
+
 
     @Override
     protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res, FilterChain filterChain) {
@@ -42,7 +55,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 return;
             }
 
-            if (req.getRequestURI().startsWith("/api/v1/search") || req.getRequestURI().equals("/api/v1/spots/recommendations")) {
+            if (publicUrls.matches(req)) {
                 if (req.getHeader("Authorization") == null) {
                     filterChain.doFilter(req, res);
                     return;

--- a/backend/src/main/resources/application-aws.yml
+++ b/backend/src/main/resources/application-aws.yml
@@ -37,7 +37,7 @@ s3:
 
 kakao:
   client-id: ${KAKAO_REST_API_KEY}
-  redirect-uri: http://localhost:5173/login
+  redirect-uri: https://mungtivity.vercel.app/login
   client-secret: ${KAKAO_CLIENT_SECRET}
 
 jwt:


### PR DESCRIPTION
## 📋 Summary
<!-- 이 PR에서 변경된 주요 내용을 간략히 작성해주세요. -->
- 장소펜션 상세조회 관련 시큐리티 수정 : RequestMatcher 사용하여 List로 허용 URL 관리
- 프로필 이미지 등록 presignedUrl 사용
- 마이페이지 조회 시, 프로필 이미지 없는 강아지까지 조회되도록 쿼리 수정

## ✨ Feature Details
| Method | Path                      | Description      |
|--------|---------------------------|------------------|


## 💡 Key Considerations
<!-- 구현하면서 고려한 점, 또는 해결한 주요 이슈를 간단히 작성해주세요. -->


## ✅ Checklist
- [ ] 코드를 스스로 검토했나요?
- [ ] 필요한 테스트를 추가하고 모두 통과했나요?
- [ ] 브랜치 전략에 맞는 브랜치에 PR을 올렸나요?
- [ ] 커밋 메시지가 컨벤션에 맞나요?
- [ ] 필요한 문서를 업데이트했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
	- 프로필 이미지 처리를 위한 새로운 엔드포인트 추가: `generatePreSignedUrlForMProfileImage`.
- **변경 사항**
	- 프로필 이미지 관련 메서드에서 `MultipartFile` 대신 `String fileKey` 사용.
	- `PuppyRepository`의 쿼리 변경: `INNER JOIN`에서 `LEFT JOIN`으로 수정.
	- `JwtAuthenticationFilter`에서 공용 URL 요청 처리를 위한 새로운 매처 추가.
	- 카카오 리다이렉트 URI 업데이트: `http://localhost:5173/login`에서 `https://mungtivity.vercel.app/login`으로 변경.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->