### PR TITLE
KAN-106-BE-feat/imageResize : 강아지 프로필 사진 없으면 npe 터지는 오류 해결

### DIFF
--- a/backend/src/main/java/com/meong9/backend/domain/member/service/MemberService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/member/service/MemberService.java
@@ -172,7 +172,9 @@ public class MemberService {
                 .map(puppy -> MypagePuppyDto.builder()
                         .puppyId(puppy.getPuppyId())
                         .puppyName(puppy.getName())
-                        .puppyImageUrl(puppy.getProfileImage().getFileUrl())
+                        .puppyImageUrl(
+                                puppy.getProfileImage() != null ? puppy.getProfileImage().getFileUrl() : null
+                        )
                         .build())
                 .toList();
         return MypageDto.builder()


### PR DESCRIPTION
## 📋 Summary
<!-- 이 PR에서 변경된 주요 내용을 간략히 작성해주세요. -->
- 강아지 프로필 사진 없으면 npe 터지는 오류 해결

## ✨ Feature Details
| Method | Path                      | Description      |
|--------|---------------------------|------------------|


## 💡 Key Considerations
<!-- 구현하면서 고려한 점, 또는 해결한 주요 이슈를 간단히 작성해주세요. -->


## ✅ Checklist
- [ ] 코드를 스스로 검토했나요?
- [ ] 필요한 테스트를 추가하고 모두 통과했나요?
- [ ] 브랜치 전략에 맞는 브랜치에 PR을 올렸나요?
- [ ] 커밋 메시지가 컨벤션에 맞나요?
- [ ] 필요한 문서를 업데이트했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- `getMyPage` 메서드에서 널 안전성을 개선하여 `NullPointerException` 발생 가능성을 방지했습니다.
  
- **새로운 기능**
	- 회원 정보 삽입 및 업데이트 메서드의 매개변수를 `MultipartFile`로 변경하여 프로필 이미지 처리를 단순화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->