### PR TITLE
From KAN-111-BE-refactor/review to dev

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -70,6 +70,9 @@ dependencies {
 	// caffeine
 	implementation 'com.github.ben-manes.caffeine:caffeine:3.1.6'
 
+	// webp 처리
+	implementation 'org.sejda.imageio:webp-imageio:0.1.6'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/backend/src/main/java/com/meong9/backend/domain/review/controller/ReviewController.java
+++ b/backend/src/main/java/com/meong9/backend/domain/review/controller/ReviewController.java
@@ -35,9 +35,7 @@ public class ReviewController {
     }
 
     @GetMapping("/reviews")
-    public ResponseEntity<?> getMyReviews(@CurrentMember Member member, @PageableDefault(size = 5, sort = "reviewId",
-                                          direction = Sort.Direction.DESC) Pageable pageable,
-    @RequestParam(value = "lastReviewId", required = false) Long lastReviewId) {
+    public ResponseEntity<?> getMyReviews(@CurrentMember Member member) {
         return CommonResponse.ok("success",reviewService.getMyReviews(member));
     }
 

--- a/backend/src/main/java/com/meong9/backend/domain/review/dto/FileResponseDto.java
+++ b/backend/src/main/java/com/meong9/backend/domain/review/dto/FileResponseDto.java
@@ -20,4 +20,11 @@ public class FileResponseDto {
         this.fileUrl = file.getFileUrl();
         this.fileName = file.getFileName();
     }
+
+    public FileResponseDto(FileType fileType, Integer fileSize, String fileUrl, String fileName) {
+        this.fileType = fileType;
+        this.fileSize = fileSize;
+        this.fileUrl = fileUrl;
+        this.fileName = fileName;
+    }
 }

--- a/backend/src/main/java/com/meong9/backend/domain/review/dto/MyReviewResponseDto.java
+++ b/backend/src/main/java/com/meong9/backend/domain/review/dto/MyReviewResponseDto.java
@@ -18,23 +18,23 @@ public class MyReviewResponseDto {
     private final String content;
     private final Float score;
     private final LocalDate visitDate;
+    private final FileResponseDto file;
     private final String type;
     private final Long plcPenId;
+    private final String plcPenName;
     private final String nickname;
-    private FileResponseDto file;
-
-    @Setter
-    private String plcPenName;
 
     public MyReviewResponseDto(Long reviewId, String content, Float score, LocalDate visitDate,
-                               String type, Long plcPenId, String nickname, ReviewFile reviewFile) {
+                               String type, Long plcPenId, String plcPenName, String nickname,
+                               FileResponseDto file) {
         this.reviewId = reviewId;
         this.content = content;
         this.score = score;
         this.visitDate = visitDate;
         this.type = type;
         this.plcPenId = plcPenId;
+        this.plcPenName = plcPenName;
         this.nickname = nickname;
-        if(reviewFile != null) this.file=new FileResponseDto(reviewFile);
+        this.file=file;
     }
 }

--- a/backend/src/main/java/com/meong9/backend/domain/review/entity/Review.java
+++ b/backend/src/main/java/com/meong9/backend/domain/review/entity/Review.java
@@ -11,6 +11,12 @@ import java.util.Collections;
 import java.util.List;
 
 @Entity
+@Table(
+        name = "review",
+        indexes = {
+                @Index(name = "idx_review_member_type", columnList = "member_id, type")
+        }
+)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class Review extends BaseTimeEntity {

--- a/backend/src/main/java/com/meong9/backend/domain/review/repository/ReviewRepository.java
+++ b/backend/src/main/java/com/meong9/backend/domain/review/repository/ReviewRepository.java
@@ -29,7 +29,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
         """)
     List<Review> findTop10RecentReviews();
 
-    @Query("SELECT new com.meong9.backend.domain.review.dto.MyReviewResponseDto(" +
+    @Query("SELECT DISTINCT new com.meong9.backend.domain.review.dto.MyReviewResponseDto(" +
             "r.reviewId, r.content, r.score, r.visitDate, r.type, r.placePensionId, " +
             "CASE WHEN r.type = '010' THEN p.name WHEN r.type = '020' THEN ps.name ELSE null END, r.nickname, " +
             "new com.meong9.backend.domain.review.dto.FileResponseDto(mf.fileType, mf.fileSize, mf.fileUrl, mf.fileName)) " +

--- a/backend/src/main/java/com/meong9/backend/domain/review/repository/ReviewRepository.java
+++ b/backend/src/main/java/com/meong9/backend/domain/review/repository/ReviewRepository.java
@@ -29,7 +29,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
         """)
     List<Review> findTop10RecentReviews();
 
-    @Query("SELECT DISTINCT new com.meong9.backend.domain.review.dto.MyReviewResponseDto(" +
+    @Query("SELECT new com.meong9.backend.domain.review.dto.MyReviewResponseDto(" +
             "r.reviewId, r.content, r.score, r.visitDate, r.type, r.placePensionId, " +
             "CASE WHEN r.type = '010' THEN p.name WHEN r.type = '020' THEN ps.name ELSE null END, r.nickname, " +
             "new com.meong9.backend.domain.review.dto.FileResponseDto(mf.fileType, mf.fileSize, mf.fileUrl, mf.fileName)) " +

--- a/backend/src/main/java/com/meong9/backend/domain/review/repository/ReviewRepository.java
+++ b/backend/src/main/java/com/meong9/backend/domain/review/repository/ReviewRepository.java
@@ -30,9 +30,14 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     List<Review> findTop10RecentReviews();
 
     @Query("SELECT new com.meong9.backend.domain.review.dto.MyReviewResponseDto(" +
-            "r.reviewId, r.content, r.score, r.visitDate, r.type, r.placePensionId, r.nickname, rf)" +
+            "r.reviewId, r.content, r.score, r.visitDate, r.type, r.placePensionId, " +
+            "CASE WHEN r.type = '010' THEN p.name WHEN r.type = '020' THEN ps.name ELSE null END, r.nickname, " +
+            "new com.meong9.backend.domain.review.dto.FileResponseDto(mf.fileType, mf.fileSize, mf.fileUrl, mf.fileName)) " +
             "FROM Review r " +
             "LEFT JOIN r.reviewFiles rf " +
+            "LEFT JOIN rf.file mf " +
+            "LEFT JOIN Place p ON r.placePensionId = p.placeId AND r.type = '010' " +
+            "LEFT JOIN Pension ps ON r.placePensionId = ps.pensionId AND r.type = '020' " +
             "WHERE r.member = :member")
     List<MyReviewResponseDto> findReviewsByMember(@Param("member") Member member);
 

--- a/backend/src/main/java/com/meong9/backend/domain/review/service/ReviewService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/review/service/ReviewService.java
@@ -80,14 +80,6 @@ public class ReviewService {
     @Transactional(readOnly = true)
     public List<MyReviewResponseDto> getMyReviews(Member member) {
         List<MyReviewResponseDto> reviews = reviewRepository.findReviewsByMember(member);
-        for (MyReviewResponseDto reviewDto : reviews) {
-            if(Objects.equals(reviewDto.getType(), "010")){ // 장소
-                reviewDto.setPlcPenName(placeRepository.findNameByPlaceId(reviewDto.getPlcPenId()));
-            }
-            if(Objects.equals(reviewDto.getType(), "020")){ // 펜션
-                reviewDto.setPlcPenName(pensionRepository.findNameByPensionId(reviewDto.getPlcPenId()));
-            }
-        }
 
         return reviews;
     }

--- a/backend/src/main/java/com/meong9/backend/domain/review/service/ReviewService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/review/service/ReviewService.java
@@ -119,7 +119,6 @@ public class ReviewService {
     @Transactional
     public void createReview(ReviewRequestDto reviewRequestDto, List<MultipartFile> files, Member member) {
         List<MediaFile> mediaFiles = new ArrayList<>();
-        log.info("내용: {}",reviewRequestDto.getContent());
         Review review = Review.builder()
                 .member(member)
                 .content(banWordInspector.mask(reviewRequestDto.getContent(),"멍멍"))

--- a/backend/src/main/java/com/meong9/backend/global/mediafile/service/MediaFileService.java
+++ b/backend/src/main/java/com/meong9/backend/global/mediafile/service/MediaFileService.java
@@ -129,6 +129,15 @@ public class MediaFileService {
         if (!List.of("jpg", "jpeg", "png", "webp", "mp4", "mov").contains(fileExtension)) {
             throw BadRequestException.invalidImageVideoFormat();
         }
+
+        // Webp 이미지인 경우 변환
+        if (fileExtension.equals("webp")) {
+            try {
+                Class.forName("com.luciad.imageio.webp.WebPReadParam");
+            } catch (ClassNotFoundException e) {
+                throw BadRequestException.invalidImageVideoFormat();
+            }
+        }
     }
 
 

--- a/backend/src/main/java/com/meong9/backend/global/mediafile/service/MediaFileService.java
+++ b/backend/src/main/java/com/meong9/backend/global/mediafile/service/MediaFileService.java
@@ -126,7 +126,7 @@ public class MediaFileService {
         String fileExtension = originalFilename.substring(originalFilename.lastIndexOf('.') + 1).toLowerCase();
 
         // 허용 확장자를 소문자로 비교
-        if (!List.of("jpg", "jpeg", "png","mp4","mov").contains(fileExtension)) {
+        if (!List.of("jpg", "jpeg", "png", "webp", "mp4", "mov").contains(fileExtension)) {
             throw BadRequestException.invalidImageVideoFormat();
         }
     }


### PR DESCRIPTION
## 📋 Summary
- 내 리뷰 조회 쿼리 개선

## ✨ Feature Details


## 💡 Key Considerations
<!-- 구현하면서 고려한 점, 또는 해결한 주요 이슈를 간단히 작성해주세요. -->
### v1
```java
List<MyReviewResponseDto> reviews = reviewRepository.findReviewsByMember(member);
for (MyReviewResponseDto reviewDto : reviews) {
	if(Objects.equals(reviewDto.getType(), "010")){ // 장소
		reviewDto.setPlcPenName(placeRepository.findNameByPlaceId(reviewDto.getPlcPenId()));
	}
		
  if(Objects.equals(reviewDto.getType(), "020")){ // 펜션
    reviewDto.setPlcPenName(pensionRepository.findNameByPensionId(reviewDto.getPlcPenId()));
  }
}
```

```sql
SELECT 
    r.review_id AS reviewId,
    r.content,
    r.score,
    r.visit_date AS visitDate,
    r.type,
    r.place_pension_id AS placePensionId,
    r.nickname,
    rf.*  -- reviewFiles 필드 전체를 가져옴
FROM 
    review r
LEFT JOIN 
    review_files rf 
ON 
    r.review_id = rf.review_id  -- 두 테이블 간의 관계를 기준으로 JOIN 수행
WHERE 
    r.member_id = ?;  -- :member 바인딩 파라미터는 ?로 변환
```

- N+1 문제 발생
    - 메인 쿼리에서 `Review` 엔티티를 1번 조회.
    - 각 `Review`에 연결된 `ReviewFiles`을 조회할 때 N개의 쿼리가 추가로 발생.
    - `rf` 필드를 DTO에 직접 할당하면서 **LEFT JOIN**을 사용하지만, 컬렉션 관계가 프록시로 남아 있는 경우, `rf`에 대해 **하나씩 추가 쿼리가 발생**
- 이후 반복문 돌면서 리뷰의 개수만큼 쿼리 추가 실행

### v2
```java
List<MyReviewResponseDto> reviews = reviewRepository.findReviewsByMember(member);
```

```sql
SELECT
    r.review_id AS reviewId,
    r.content AS content,
    r.score AS score,
    r.visit_date AS visitDate,
    r.type AS type,
    r.plc_pen_id AS placePensionId,
    CASE
        WHEN r.type = '010' THEN p.place_name
        WHEN r.type = '020' THEN ps.pension_name
        ELSE NULL
    END AS plcPenName,
    r.m_nickname AS nickname,
    mf.file_type AS fileType,
    mf.file_size AS fileSize,
    mf.file_url AS fileUrl,
    mf.file_name AS fileName
FROM
    review r
LEFT JOIN
    review_file rf ON r.review_id = rf.review_id
LEFT JOIN
    media_file mf ON rf.media_file_id = mf.media_file_id
LEFT JOIN
    place p ON r.plc_pen_id = p.place_id AND r.type = '010'
LEFT JOIN
    pension ps ON r.plc_pen_id = ps.pension_id AND r.type = '020'
WHERE
    r.member_id = ?
```

- 한 번의 쿼리로 모든 데이터를 가져오는 방식으로 변경
    - `Review`와 관련된 `Place`와 `Pension` 데이터를 함께 조인
        - `CASE WHEN`으로 불필요한 조인 방지
    - `type` 값에 따라 `placeName` 또는 `pensionName`을 선택적으로 가져옴
    - 조회 결과를 `MyReviewResponseDto`에 매핑

## ✅ Checklist
- [x] 코드를 스스로 검토했나요?
- [x] 필요한 테스트를 추가하고 모두 통과했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올렸나요?
- [x] 커밋 메시지가 컨벤션에 맞나요?
- [x] 필요한 문서를 업데이트했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- `getMyReviews` 메소드가 단순화되어 현재 회원의 모든 리뷰를 반환합니다.
	- `FileResponseDto`에 새로운 생성자가 추가되어 인스턴스를 더 유연하게 생성할 수 있습니다.
	- `MyReviewResponseDto`가 불변 속성으로 변경되어 데이터 안정성이 향상되었습니다.
	- `Review` 클래스에 데이터베이스 인덱스가 추가되어 쿼리 성능이 개선되었습니다.
	- `findReviewsByMember` 메소드의 쿼리 로직이 개선되어 더 많은 맥락 정보를 반환합니다.
	- 이미지 및 비디오 업로드를 위한 허용 파일 확장자 목록에 `webp`가 추가되었습니다.

- **Bug Fixes**
	- `updateReview` 메소드의 이름이 `deleteReview`로 변경되어 기능과 일치하도록 수정되었습니다.

- **Chores**
	- `createReview` 메소드의 로깅 문구가 간소화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->