### PR TITLE
From KAN-111-BE-refactor/review to dev

### DIFF
--- a/backend/src/main/java/com/meong9/backend/domain/pension/entity/Pension.java
+++ b/backend/src/main/java/com/meong9/backend/domain/pension/entity/Pension.java
@@ -69,8 +69,14 @@ public class Pension {
     public void increaseLikeCount(){
         this.likeCount++;
     }
-
     public void decreaseLikeCount(){
         this.likeCount=Math.max(this.likeCount-1,0);
+    }
+
+    public void increaseReviewCount() {
+        this.reviewCount++;
+    }
+    public void decreaseReviewCount() {
+        this.reviewCount = Math.max(this.reviewCount - 1, 0);
     }
 }

--- a/backend/src/main/java/com/meong9/backend/domain/pension/repository/PensionRepository.java
+++ b/backend/src/main/java/com/meong9/backend/domain/pension/repository/PensionRepository.java
@@ -5,6 +5,7 @@ import com.meong9.backend.domain.member.entity.Member;
 import com.meong9.backend.domain.pension.dto.PensionSummaryResponseDto;
 import com.meong9.backend.domain.pension.entity.Pension;
 import com.meong9.backend.domain.recommendation.recommendation.projection.PlcPenProjection;
+import com.meong9.backend.domain.review.dto.ReviewInfoQueryResult;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -76,6 +77,14 @@ public interface PensionRepository extends JpaRepository<Pension, Long> {
     @EntityGraph(attributePaths = {"pensionFiles.mediaFile"})
     @Query("SELECT p FROM Pension p WHERE p.pensionId = :pensionId")
     Optional<Pension> findByPensionIdWithImage(@Param("pensionId") Long pensionId);
+
+    @Query("SELECT new com.meong9.backend.domain.review.dto.ReviewInfoQueryResult(p, COUNT(r)) " +
+            "FROM Pension p " +
+            "LEFT JOIN Review r ON r.placePensionId = p.pensionId AND r.type = :type " +
+            "WHERE p.pensionId = :pensionId " +
+            "GROUP BY p")
+    Optional<ReviewInfoQueryResult> findByPensionIdWithImageAndReviewCount(@Param("pensionId") Long pensionId,
+                                                                         @Param("type") String type);
 
     @EntityGraph(attributePaths = {"pensionFiles.mediaFile"})
     @Query("""

--- a/backend/src/main/java/com/meong9/backend/domain/place/entity/Place.java
+++ b/backend/src/main/java/com/meong9/backend/domain/place/entity/Place.java
@@ -76,8 +76,14 @@ public class Place {
     public void increaseLikeCount() {
         this.likeCount++;
     }
-
     public void decreaseLikeCount() {
         this.likeCount = Math.max(this.likeCount - 1, 0);
+    }
+
+    public void increaseReviewCount() {
+        this.reviewCount++;
+    }
+    public void decreaseReviewCount() {
+        this.reviewCount = Math.max(this.reviewCount - 1, 0);
     }
 }

--- a/backend/src/main/java/com/meong9/backend/domain/place/repository/PlaceRepository.java
+++ b/backend/src/main/java/com/meong9/backend/domain/place/repository/PlaceRepository.java
@@ -1,10 +1,10 @@
 package com.meong9.backend.domain.place.repository;
 
-import com.meong9.backend.domain.member.entity.Member;
 import com.meong9.backend.domain.place.dto.PlaceInfoDto;
 import com.meong9.backend.domain.place.dto.PlaceSummaryResponseDto;
 import com.meong9.backend.domain.place.entity.Place;
 import com.meong9.backend.domain.recommendation.recommendation.projection.PlcPenProjection;
+import com.meong9.backend.domain.review.dto.ReviewInfoQueryResult;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -29,6 +29,14 @@ public interface PlaceRepository extends JpaRepository<Place, Long> {
     @EntityGraph(attributePaths = {"placeFiles.mediaFile"})
     @Query("SELECT p FROM Place p WHERE p.placeId = :placeId")
     Optional<Place> findByPlaceIdWithImage(@Param("placeId")Long id);
+
+    @Query("SELECT new com.meong9.backend.domain.review.dto.ReviewInfoQueryResult(p, COUNT(r)) " +
+            "FROM Place p " +
+            "LEFT JOIN Review r ON r.placePensionId = p.placeId AND r.type = :type " +
+            "WHERE p.placeId = :placeId " +
+            "GROUP BY p")
+    Optional<ReviewInfoQueryResult> findByPlaceIdWithImageAndReviewCount(@Param("placeId") Long placeId,
+                                                                         @Param("type") String type);
 
     @Query(""" 
     SELECT new com.meong9.backend.domain.place.dto.PlaceSummaryResponseDto(

--- a/backend/src/main/java/com/meong9/backend/domain/review/controller/ReviewController.java
+++ b/backend/src/main/java/com/meong9/backend/domain/review/controller/ReviewController.java
@@ -48,7 +48,7 @@ public class ReviewController {
     public ResponseEntity<?> createReview(
             @Valid @RequestPart("data") ReviewRequestDto reviewRequestDto,
             @RequestPart(value = "file", required = false) List<MultipartFile> files,
-            @CurrentMember Member member) throws IOException, InterruptedException, TimeoutException {
+            @CurrentMember Member member)  {
         reviewService.createReview(reviewRequestDto,files,member);
         return CommonResponse.created("success");
     }

--- a/backend/src/main/java/com/meong9/backend/domain/review/dto/ReviewInfoQueryResult.java
+++ b/backend/src/main/java/com/meong9/backend/domain/review/dto/ReviewInfoQueryResult.java
@@ -1,0 +1,23 @@
+package com.meong9.backend.domain.review.dto;
+
+import com.meong9.backend.domain.pension.entity.Pension;
+import com.meong9.backend.domain.place.entity.Place;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+public class ReviewInfoQueryResult {
+    private Place place;
+    private Pension pension;
+    private Long reviewCount;
+
+    public ReviewInfoQueryResult(Place place, Long reviewCount) {
+        this.place = place;
+        this.reviewCount = reviewCount;
+    }
+
+    public ReviewInfoQueryResult(Pension pension, Long reviewCount) {
+        this.pension = pension;
+        this.reviewCount = reviewCount;
+    }
+}

--- a/backend/src/main/java/com/meong9/backend/domain/review/service/ReviewService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/review/service/ReviewService.java
@@ -28,7 +28,6 @@ import com.meong9.backend.global.mediafile.service.MediaFileService;
 import com.meong9.backend.global.utils.AddressMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
@@ -90,28 +89,33 @@ public class ReviewService {
         String fullAddress=plcPenAddressRepository.findFullAddress(type, plcPenId)
                 .orElseThrow(() -> NotFoundException
                         .entityNotFound("찾으시는 주소가 없습니다, type: " +type+", id: " + plcPenId));
+
         if(Objects.equals(type, "010")){ // 장소
-            Place place=placeRepository.findByPlaceIdWithImage(plcPenId)
+            ReviewInfoQueryResult queryResult=placeRepository.findByPlaceIdWithImageAndReviewCount(plcPenId,type)
                     .orElseThrow(() -> NotFoundException
                     .entityNotFound("type: " +type+", place_id: " + plcPenId));
+            Place place = queryResult.getPlace();
+            Integer reviewCount =  Math.toIntExact(queryResult.getReviewCount());
             String fileUrl=null;
-            if(place.getPlaceFiles() != null) {
+            if(!place.getPlaceFiles().isEmpty()) {
                 fileUrl=place.getPlaceFiles().get(0).getMediaFile().getFileUrl(); // 0번째 사진 가져오기
             }
-
-            return new PlacePensionInfoResponseDto.PlaceResponse(place.getName(),fullAddress,place.getReviewAvg(),place.getReviewCount(),fileUrl,place.getLikeCount());
+            return new PlacePensionInfoResponseDto.PlaceResponse(place.getName(),fullAddress,place.getReviewAvg(),reviewCount,fileUrl,place.getLikeCount());
         }
+
         if(Objects.equals(type, "020")){ // 펜션
-            Pension pension=pensionRepository.findByPensionIdWithImage(plcPenId)
+            ReviewInfoQueryResult queryResult=pensionRepository.findByPensionIdWithImageAndReviewCount(plcPenId,type)
                     .orElseThrow(() -> NotFoundException
-                            .entityNotFound("type: " +type+", pension_id: " + plcPenId));
+                            .entityNotFound("type: " +type+", place_id: " + plcPenId));
+            Pension pension = queryResult.getPension();
+            Integer reviewCount =  Math.toIntExact(queryResult.getReviewCount());
 
             String fileUrl=null;
-            if(pension.getPensionFiles() != null) {
+            if(!pension.getPensionFiles().isEmpty()) {
                 fileUrl=pension.getPensionFiles().get(0).getMediaFile().getFileUrl(); // 0번째 사진 가져오기
             }
 
-            return new PlacePensionInfoResponseDto.PensionResponse(pension.getName(),fullAddress,pension.getReviewAvg(),pension.getReviewCount(),fileUrl,pension.getLikeCount());
+            return new PlacePensionInfoResponseDto.PensionResponse(pension.getName(),fullAddress,pension.getReviewAvg(),reviewCount,fileUrl,pension.getLikeCount());
         }
         return null;
     }
@@ -132,6 +136,13 @@ public class ReviewService {
 
         Review savedReview = reviewRepository.save(review);
 
+//        if(Objects.equals(reviewRequestDto.getType(), "010")){
+//            Place place=placeRepository.findById(savedReview.getPlacePensionId()).orElseThrow(() -> NotFoundException.entityNotFound("장소"));
+//
+//        }
+//        if(Objects.equals(reviewRequestDto.getType(), "020")){
+//
+//        }
         processFileAsync(files, savedReview, mediaFiles);
 
         memberScoreService.addReview(member.getMemberId(), reviewRequestDto.getPlcPenId(), reviewRequestDto.getScore(), reviewRequestDto.getType());

--- a/backend/src/main/java/com/meong9/backend/domain/review/service/ReviewService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/review/service/ReviewService.java
@@ -106,7 +106,7 @@ public class ReviewService {
         if(Objects.equals(type, "020")){ // 펜션
             ReviewInfoQueryResult queryResult=pensionRepository.findByPensionIdWithImageAndReviewCount(plcPenId,type)
                     .orElseThrow(() -> NotFoundException
-                            .entityNotFound("type: " +type+", place_id: " + plcPenId));
+                            .entityNotFound("type: " +type+", pension_id: " + plcPenId));
             Pension pension = queryResult.getPension();
             Integer reviewCount =  Math.toIntExact(queryResult.getReviewCount());
 
@@ -141,7 +141,7 @@ public class ReviewService {
             place.increaseReviewCount();
         }
         if(Objects.equals(reviewRequestDto.getType(), "020")){
-            Pension pension=pensionRepository.findById(savedReview.getPlacePensionId()).orElseThrow(() -> NotFoundException.entityNotFound("장소"));
+            Pension pension=pensionRepository.findById(savedReview.getPlacePensionId()).orElseThrow(() -> NotFoundException.entityNotFound("펜션"));
             pension.increaseReviewCount();
         }
         processFileAsync(files, savedReview, mediaFiles);
@@ -191,7 +191,7 @@ public class ReviewService {
         return CompletableFuture.completedFuture(null);
     }
 
-    @Retryable( // 재시도 로직 정의
+    @Retryable( // 재시도 로직
             value = TimeoutException.class,
             maxAttempts = 3,
             backoff = @Backoff(delay = 2000)
@@ -291,7 +291,7 @@ public class ReviewService {
             place.decreaseReviewCount();
         }
         if(Objects.equals(review.getType(), "020")){
-            Pension pension=pensionRepository.findById(review.getPlacePensionId()).orElseThrow(() -> NotFoundException.entityNotFound("장소"));
+            Pension pension=pensionRepository.findById(review.getPlacePensionId()).orElseThrow(() -> NotFoundException.entityNotFound("펜션"));
             pension.decreaseReviewCount();
         }
         memberScoreService.deleteReview(member.getMemberId(), review.getPlacePensionId(), review.getScore(), review.getType());

--- a/backend/src/main/java/com/meong9/backend/domain/review/service/ReviewService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/review/service/ReviewService.java
@@ -136,13 +136,14 @@ public class ReviewService {
 
         Review savedReview = reviewRepository.save(review);
 
-//        if(Objects.equals(reviewRequestDto.getType(), "010")){
-//            Place place=placeRepository.findById(savedReview.getPlacePensionId()).orElseThrow(() -> NotFoundException.entityNotFound("장소"));
-//
-//        }
-//        if(Objects.equals(reviewRequestDto.getType(), "020")){
-//
-//        }
+        if(Objects.equals(reviewRequestDto.getType(), "010")){
+            Place place=placeRepository.findById(savedReview.getPlacePensionId()).orElseThrow(() -> NotFoundException.entityNotFound("장소"));
+            place.increaseReviewCount();
+        }
+        if(Objects.equals(reviewRequestDto.getType(), "020")){
+            Pension pension=pensionRepository.findById(savedReview.getPlacePensionId()).orElseThrow(() -> NotFoundException.entityNotFound("장소"));
+            pension.increaseReviewCount();
+        }
         processFileAsync(files, savedReview, mediaFiles);
 
         memberScoreService.addReview(member.getMemberId(), reviewRequestDto.getPlcPenId(), reviewRequestDto.getScore(), reviewRequestDto.getType());
@@ -284,6 +285,15 @@ public class ReviewService {
         // 리뷰 삭제 (ReviewFile은 CascadeType.ALL로 자동 삭제)
         reviewRepository.delete(review);
 
+        // 리뷰 개수 감소
+        if(Objects.equals(review.getType(), "010")){
+            Place place=placeRepository.findById(review.getPlacePensionId()).orElseThrow(() -> NotFoundException.entityNotFound("장소"));
+            place.decreaseReviewCount();
+        }
+        if(Objects.equals(review.getType(), "020")){
+            Pension pension=pensionRepository.findById(review.getPlacePensionId()).orElseThrow(() -> NotFoundException.entityNotFound("장소"));
+            pension.decreaseReviewCount();
+        }
         memberScoreService.deleteReview(member.getMemberId(), review.getPlacePensionId(), review.getScore(), review.getType());
     }
 


### PR DESCRIPTION
## 📋 Summary
- 리뷰 작성 화면에서 장소/펜션의 리뷰 갯수 출력


## ✨ Feature Details

## 💡 Key Considerations
- Place, Pension의 reviewCount를 쓰게 되면 reviewCount의 값과 실제 리뷰 개수와 일치하지 않는 문제가 생길 수 있어서 count 쿼리로 개수 조회
```java
 @Query("SELECT new com.meong9.backend.domain.review.dto.ReviewInfoQueryResult(p, COUNT(r)) " +
            "FROM Place p " +
            "LEFT JOIN Review r ON r.placePensionId = p.placeId AND r.type = :type " +
            "WHERE p.placeId = :placeId " +
            "GROUP BY p")
    Optional<ReviewInfoQueryResult> findByPlaceIdWithImageAndReviewCount(@Param("placeId") Long placeId,
                                                                         @Param("type") String type);
```
- Pension도 동일한 방법으로 조회

### 
## ✅ Checklist
- [x] 코드를 스스로 검토했나요?
- [x] 필요한 테스트를 추가하고 모두 통과했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올렸나요?
- [x] 커밋 메시지가 컨벤션에 맞나요?
- [x] 필요한 문서를 업데이트했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **신규 기능**
	- 펜션 및 장소 정보와 관련된 리뷰 수를 함께 조회할 수 있는 메소드 추가.
	- 리뷰 정보를 포함하는 새로운 데이터 구조 `ReviewInfoQueryResult` 도입.
	- 리뷰 수를 관리하기 위한 메소드 `increaseReviewCount()` 및 `decreaseReviewCount()` 추가.

- **버그 수정**
	- 리뷰 삭제 메소드의 잘못된 이름 수정.

- **문서화**
	- 메소드 시그니처 및 반환 타입 업데이트로 인해 문서화 필요.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->