### PR TITLE
From KAN-106-BE-feat/imageResize into dev : 지도 검색 / 프로필 이미지 조회 / 시큐리티 수정

### DIFF
--- a/backend/src/main/java/com/meong9/backend/domain/member/service/MemberService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/member/service/MemberService.java
@@ -174,16 +174,15 @@ public class MemberService {
                         .puppyId(puppy.getPuppyId())
                         .puppyName(puppy.getName())
                         .puppyImageUrl(
-                                puppy.getProfileImage() != null ?
-                                        mediaFileService.getResizeBucketUrl(puppy.getProfileImage().getFileKey()) : null
+                                puppy.getProfileImage() != null ? puppy.getProfileImage().getFileUrl() : null
                         )
                         .build())
                 .toList();
         return MypageDto.builder()
                 .memberId(foundMember.getMemberId())
                 .nickname(foundMember.getNickname())
-                .profileImageUrl(foundMember.getProfileImage() != null ?
-                        mediaFileService.getResizeBucketUrl(foundMember.getProfileImage().getFileKey()): null)
+                .profileImageUrl(foundMember.getProfileImage() != null ? foundMember.getProfileImage().getFileUrl(): null
+                )
                 .puppyList(puppyList)
                 .build();
     }
@@ -200,7 +199,8 @@ public class MemberService {
                 .nickname(foundMember.getNickname())
                 .phone(foundMember.getPhone())
                 .profileImageUrl(foundMember.getProfileImage() != null ?
-                        mediaFileService.getResizeBucketUrl(foundMember.getProfileImage().getFileKey()): null)
+                        foundMember.getProfileImage().getFileUrl(): null
+                )
                 .build();
     }
 

--- a/backend/src/main/java/com/meong9/backend/domain/pension/repository/PensionRepository.java
+++ b/backend/src/main/java/com/meong9/backend/domain/pension/repository/PensionRepository.java
@@ -64,7 +64,7 @@ public interface PensionRepository extends JpaRepository<Pension, Long> {
     Optional<Pension> findByPensionId(@Param("pensionId") Long pensionId);
 
     @Query("""
-    SELECT new com.meong9.backend.domain.pension.dto.PensionSummaryResponseDto(
+    SELECT DISTINCT new com.meong9.backend.domain.pension.dto.PensionSummaryResponseDto(
     p.name,
     p.reviewAvg,
     p.reviewCount
@@ -86,15 +86,16 @@ public interface PensionRepository extends JpaRepository<Pension, Long> {
     Optional<ReviewInfoQueryResult> findByPensionIdWithImageAndReviewCount(@Param("pensionId") Long pensionId,
                                                                          @Param("type") String type);
 
-    @EntityGraph(attributePaths = {"pensionFiles.mediaFile"})
     @Query("""
-    SELECT P,
+    SELECT DISTINCT P,
            CASE WHEN EXISTS (SELECT 1
                 FROM PensionLike pl
                 JOIN Like l ON pl.likeId = l.likeId
             WHERE l.member.memberId = :memberId AND pl.pension.pensionId = P.pensionId) 
             THEN TRUE ELSE FALSE END AS LIKED 
     FROM Pension P
+    LEFT JOIN P.pensionFiles pf
+    LEFT JOIN pf.mediaFile
     WHERE P.pensionId IN :pensionIds
     """)
     List<Object[]> findAllWithLikeStatus(

--- a/backend/src/main/java/com/meong9/backend/domain/place/repository/PlaceRepository.java
+++ b/backend/src/main/java/com/meong9/backend/domain/place/repository/PlaceRepository.java
@@ -48,15 +48,16 @@ public interface PlaceRepository extends JpaRepository<Place, Long> {
     """)
     Optional<PlaceSummaryResponseDto> findPlaceSummaryResponseDtoById(@Param("placeId") Long placeId);
 
-    @EntityGraph(attributePaths = {"placeFiles.mediaFile"})
     @Query("""
-    SELECT P,
+    SELECT DISTINCT P,
            CASE WHEN EXISTS (SELECT 1
                 FROM PlaceLike pl
                 JOIN Like l ON pl.likeId = l.likeId
             WHERE l.member.memberId = :memberId AND pl.place.placeId = P.placeId) 
             THEN TRUE ELSE FALSE END AS LIKED 
     FROM Place P
+    LEFT JOIN P.placeFiles pf
+    LEFT JOIN pf.mediaFile
     WHERE P.placeId IN :placeIds
     """)
     List<Object[]> findAllWithLikeStatus(
@@ -94,11 +95,6 @@ public interface PlaceRepository extends JpaRepository<Place, Long> {
      */
     @Query("SELECT p FROM Place p LEFT JOIN FETCH p.placeTags WHERE p.placeId IN :placeIds")
     List<Place> findByPlaceIds(@Param("placeIds") List<Long> placeIds);
-
-    @Query("SELECT p.name FROM Place p WHERE p.placeId = :placeId")
-    String findNameByPlaceId(@Param("placeId") Long placeId); // 이름만 조회
-    @Query("SELECT c.plcCategoryId FROM Place p JOIN p.plcCategory c WHERE p.placeId = :placeId")
-    List<Long> findCategoryIdsByPensionId(@Param("placeId") Long placeId);
 
     @Query("SELECT p FROM Place p WHERE p.placeId IN :ids")
     List<Place> findAllByIdIn(@Param("ids") List<Long> ids);

--- a/backend/src/main/java/com/meong9/backend/global/auth/config/SecurityConfig.java
+++ b/backend/src/main/java/com/meong9/backend/global/auth/config/SecurityConfig.java
@@ -72,7 +72,6 @@ public class SecurityConfig {
                         new AntPathRequestMatcher("/api/v1/pensions/{pensionId}/summary", HttpMethod.GET.name()),
                         new AntPathRequestMatcher("/api/v1/places/{placeId}/reviews", HttpMethod.GET.name()),
                         new AntPathRequestMatcher("/api/v1/places/{placeId}/summary", HttpMethod.GET.name()),
-                        new AntPathRequestMatcher("/api/v1/map/places", HttpMethod.GET.name()),
                         new AntPathRequestMatcher("/api/v1/photos", HttpMethod.GET.name()),
                         new AntPathRequestMatcher("/api/v1/places/{category}/top", HttpMethod.GET.name()),
                         new AntPathRequestMatcher("/api/v1/pensions/top", HttpMethod.GET.name()),
@@ -87,16 +86,11 @@ public class SecurityConfig {
                 .requestMatchers(ignoredRequests).permitAll()
                 .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll() // 정적 리소스 허용
                 .requestMatchers(HttpMethod.GET, "/api/v1/search/**", "/api/v1/spots/recommendations",
-                        "/api/v1/map/search", "/api/v1/pensions/detail/{pensionId}",
-                        "/api/v1/places/detail/{placeId}").permitAll()
+                        "/api/v1/pensions/detail/{pensionId}", "/api/v1/places/detail/{placeId}").permitAll()
                 .requestMatchers("/index.html", "/favicon.ico").permitAll()
                 .requestMatchers(HttpMethod.GET, "/ping", "/error", "/actuator/health").permitAll() // 헬스 체크 허용
                 .anyRequest().authenticated() // 나머지 요청은 MEMBER 역할 필요
         );
-
-//        http.authorizeHttpRequests(auth -> auth
-//                .anyRequest().permitAll() // 모든 요청 허용
-//        );
 
         // CSRF 비활성화 및 CORS 설정
         http.csrf(AbstractHttpConfigurer::disable)

--- a/backend/src/main/java/com/meong9/backend/global/auth/filter/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/meong9/backend/global/auth/filter/JwtAuthenticationFilter.java
@@ -34,8 +34,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                     new AntPathRequestMatcher("/api/v1/search/**"),
                     new AntPathRequestMatcher("/api/v1/spots/recommendations"),
                     new AntPathRequestMatcher("/api/v1/pensions/detail/{pensionId}"),
-                    new AntPathRequestMatcher("/api/v1/places/detail/{placeId}"),
-                    new AntPathRequestMatcher("/api/v1/map/search")
+                    new AntPathRequestMatcher("/api/v1/places/detail/{placeId}")
             )
     );
 

--- a/backend/src/main/resources/application-aws.yml
+++ b/backend/src/main/resources/application-aws.yml
@@ -39,7 +39,7 @@ s3:
 
 kakao:
   client-id: ${KAKAO_REST_API_KEY}
-  redirect-uri: https://mungtivity.vercel.app/login
+  redirect-uri: http://localhost:5173/login
   client-secret: ${KAKAO_CLIENT_SECRET}
 
 jwt:


### PR DESCRIPTION
## 📋 Summary
<!-- 이 PR에서 변경된 주요 내용을 간략히 작성해주세요. -->
- /api/v1/map/search, /api/v1/map/places 로그인 안 한 사용자 이용 못하도록 수정
- 지도 검색 시 중복 결과 반환 수정
- 프로필 이미지 리사이즈된 이미지 사용하지 않도록 수정
- 로그인 url 복구

## ✨ Feature Details
| Method | Path                      | Description      |
|--------|---------------------------|------------------|


## 💡 Key Considerations
<!-- 구현하면서 고려한 점, 또는 해결한 주요 이슈를 간단히 작성해주세요. -->


## ✅ Checklist
- [ ] 코드를 스스로 검토했나요?
- [ ] 필요한 테스트를 추가하고 모두 통과했나요?
- [ ] 브랜치 전략에 맞는 브랜치에 PR을 올렸나요?
- [ ] 커밋 메시지가 컨벤션에 맞나요?
- [ ] 필요한 문서를 업데이트했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 프로필 이미지 URL 처리 방식 개선
	- 펜션 및 장소 관련 쿼리 메소드 업데이트로 데이터 검색 능력 향상

- **버그 수정**
	- 공용 URL 처리 방식 변경으로 인증 요구 사항 강화

- **문서화**
	- 개발 환경에 맞춰 `redirect-uri` 값 수정

- **리팩토링**
	- 불필요한 메소드 제거 및 쿼리 로직 개선

- **스타일**
	- 코드 정리 및 주석 처리된 부분 제거

<!-- end of auto-generated comment: release notes by coderabbit.ai -->