### PR TITLE
From KAN-106-BE-feat/imageResize into dev : 핫한 장소 조회 중복 결과 반환하는 문제 수정

### DIFF
--- a/backend/src/main/java/com/meong9/backend/domain/place/dto/TopPlaceResponseDto.java
+++ b/backend/src/main/java/com/meong9/backend/domain/place/dto/TopPlaceResponseDto.java
@@ -3,39 +3,41 @@ package com.meong9.backend.domain.place.dto;
 import com.meong9.backend.global.utils.AddressMapper;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.math.BigDecimal;
 
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor
 public class TopPlaceResponseDto {
-    private final Long placeId;
-    private final String placeName;
-    private final Integer reviewCount;
-    private final BigDecimal reviewAvg;
-    private final String province;
-    private final String cityDistrict;
-    private final String subDistrict;
-    private final Long viewCount;
-    private final String address;
+    private Long placeId;
+    private String placeName;
+    private Integer reviewCount;
+    private BigDecimal reviewAvg;
+    private String province;
+    private String cityDistrict;
+    private String subDistrict;
+    private String address;
+    private Long totalViewCount;
 
     @Setter
     private String placeImageUrl;
 
-    public TopPlaceResponseDto(Long placeId, String placeName, Integer reviewCount, BigDecimal reviewAvg, String province, String cityDistrict, String subDistrict, Long viewCount) {
+    public TopPlaceResponseDto(Long placeId, String placeName, Integer reviewCount, Double reviewAvg,
+                               String province, String cityDistrict, String subDistrict, Long totalViewCount) {
         this.placeId = placeId;
         this.placeName = placeName;
         this.reviewCount = reviewCount;
-        this.reviewAvg = reviewAvg;
+        this.reviewAvg = reviewAvg != null ? BigDecimal.valueOf(reviewAvg) : null;
         this.province = province;
         this.cityDistrict = cityDistrict;
         this.subDistrict = subDistrict;
-        this.viewCount = viewCount;
+        this.totalViewCount = totalViewCount;
         this.address = AddressMapper.formatAddress(province, cityDistrict, subDistrict);
     }
 
-
-
-
 }
+
+

--- a/backend/src/main/java/com/meong9/backend/domain/place/repository/TopPlaceRepository.java
+++ b/backend/src/main/java/com/meong9/backend/domain/place/repository/TopPlaceRepository.java
@@ -27,23 +27,22 @@ public interface TopPlaceRepository extends JpaRepository<TopPlace,Long> {
      * @return 상위 장소 목록과 다음 페이지 존재 여부
      */
     @Query(value = """
-        SELECT new com.meong9.backend.domain.place.dto.TopPlaceResponseDto(
-            t.placeId, t.placeName, t.reviewCount, t.reviewAvg,
-            t.province, t.cityDistrict, t.subDistrict, t.viewCount)
-        FROM TopPlace t
-        WHERE
-            (
-                (t.year = :startYear AND t.month = :startMonth AND t.date >= :startDate)\s
-                OR (t.year = :endYear AND t.month = :endMonth AND t.date <= :endDate)\s
-                OR (t.year = :startYear AND t.month > :startMonth)\s
-                OR (t.year = :endYear AND t.month < :endMonth)\s
-                OR (t.year > :startYear AND t.year < :endYear)
-            )
-            AND t.category = :category
-        GROUP BY t.placeId, t.placeName, t.reviewCount, t.reviewAvg,
-                t.province, t.cityDistrict, t.subDistrict, t.viewCount
-        ORDER BY SUM(t.viewCount) DESC
-        """)
+    SELECT new com.meong9.backend.domain.place.dto.TopPlaceResponseDto(
+        t.placeId, MAX(t.placeName), MAX(t.reviewCount), AVG(t.reviewAvg),
+        MAX(t.province), MAX(t.cityDistrict), MAX(t.subDistrict), SUM(t.viewCount))
+    FROM TopPlace t
+    WHERE
+        (
+            (t.year = :startYear AND t.month = :startMonth AND t.date >= :startDate)
+            OR (t.year = :endYear AND t.month = :endMonth AND t.date <= :endDate)
+            OR (t.year = :startYear AND t.month > :startMonth)
+            OR (t.year = :endYear AND t.month < :endMonth)
+            OR (t.year > :startYear AND t.year < :endYear)
+        )
+        AND t.category = :category
+    GROUP BY t.placeId
+    ORDER BY SUM(t.viewCount) DESC
+    """)
     Slice<TopPlaceResponseDto> findTop9PlacesByDateRangeAndCategory(
             @Param("startYear") Integer startYear,
             @Param("startMonth") Integer startMonth,
@@ -55,7 +54,7 @@ public interface TopPlaceRepository extends JpaRepository<TopPlace,Long> {
             Pageable pageable);
 
     @Query("""
-    SELECT pf.place.placeId AS placeId, mf.fileUrl AS fileUrl
+    SELECT DISTINCT pf.place.placeId AS placeId, mf.fileUrl AS fileUrl
     FROM PlaceFile pf
     JOIN pf.mediaFile mf
     WHERE pf.place.placeId IN :placeIds


### PR DESCRIPTION
## 📋 Summary
<!-- 이 PR에서 변경된 주요 내용을 간략히 작성해주세요. -->
- 핫한 장소 조회 중복 결과 반환하는 문제 수정

## ✨ Feature Details
| Method | Path                      | Description      |
|--------|---------------------------|------------------|


## 💡 Key Considerations
<!-- 구현하면서 고려한 점, 또는 해결한 주요 이슈를 간단히 작성해주세요. -->


## ✅ Checklist
- [ ] 코드를 스스로 검토했나요?
- [ ] 필요한 테스트를 추가하고 모두 통과했나요?
- [ ] 브랜치 전략에 맞는 브랜치에 PR을 올렸나요?
- [ ] 커밋 메시지가 컨벤션에 맞나요?
- [ ] 필요한 문서를 업데이트했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- `TopPlaceResponseDto` 클래스에 총 조회 수(`totalViewCount`) 필드 추가 및 평균 리뷰(`reviewAvg`) 필드 타입 변경.
	- 데이터 조회 로직 개선: 상위 9개 장소를 날짜 범위 및 카테고리로 검색하는 쿼리 업데이트, 중복 없는 대표 이미지 조회 쿼리 개선.

- **버그 수정**
	- `reviewAvg` 필드에 대한 null 체크 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->