### PR TITLE
From KAN-111-BE-refactor/review to dev: 문제 해결 

### DIFF
--- a/backend/src/main/java/com/meong9/backend/domain/review/repository/ReviewRepository.java
+++ b/backend/src/main/java/com/meong9/backend/domain/review/repository/ReviewRepository.java
@@ -38,7 +38,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
             "LEFT JOIN rf.file mf " +
             "LEFT JOIN Place p ON r.placePensionId = p.placeId AND r.type = '010' " +
             "LEFT JOIN Pension ps ON r.placePensionId = ps.pensionId AND r.type = '020' " +
-            "WHERE r.member = :member")
+            "WHERE r.member = :member ")
     List<MyReviewResponseDto> findReviewsByMember(@Param("member") Member member);
 
     @Query("""

--- a/backend/src/main/java/com/meong9/backend/domain/review/service/ReviewService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/review/service/ReviewService.java
@@ -79,7 +79,8 @@ public class ReviewService {
     @Transactional(readOnly = true)
     public List<MyReviewResponseDto> getMyReviews(Member member) {
         List<MyReviewResponseDto> reviews = reviewRepository.findReviewsByMember(member);
-
+        reviews.sort((r1, r2) -> Long.compare(r2.getReviewId(), r1.getReviewId()));
+        
         return reviews;
     }
 
@@ -135,7 +136,7 @@ public class ReviewService {
                 .build();
 
         Review savedReview = reviewRepository.save(review);
-
+        log.info("saved review: {}", savedReview);
         if(Objects.equals(reviewRequestDto.getType(), "010")){
             Place place=placeRepository.findById(savedReview.getPlacePensionId()).orElseThrow(() -> NotFoundException.entityNotFound("장소"));
             place.increaseReviewCount();

--- a/backend/src/main/java/com/meong9/backend/global/banword/inspector/BanWordInspector.java
+++ b/backend/src/main/java/com/meong9/backend/global/banword/inspector/BanWordInspector.java
@@ -4,11 +4,13 @@ import com.meong9.backend.global.banword.domain.Word;
 import com.meong9.backend.global.banword.config.InspectorConfig;
 import com.meong9.backend.global.banword.manager.ExceptWordManager;
 import com.meong9.backend.global.banword.manager.BanWordManager;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
 
+@Slf4j
 @Component
 public class BanWordInspector {
     private final BanWordManager banWordManager;
@@ -40,6 +42,7 @@ public class BanWordInspector {
     public String mask(String word, String replace) {
         StringBuilder sb = new StringBuilder(word);
         List<Word> data = inspect(word);
+
         /**
          입력: 과징금 크악 씨  이  빨
          문자 제거: 과징금크악씨이빨
@@ -51,6 +54,7 @@ public class BanWordInspector {
         for (int i = data.size() - 1; i >= 0; i--) {
             sb.replace(data.get(i).startIndex(), data.get(i).endIndex(), replace);
         }
+
         return sb.toString();
     }
 }

--- a/backend/src/main/java/com/meong9/backend/global/banword/inspector/BanWordInspector.java
+++ b/backend/src/main/java/com/meong9/backend/global/banword/inspector/BanWordInspector.java
@@ -38,10 +38,16 @@ public class BanWordInspector {
     }
 
     public String mask(String word, String replace) {
-        word=word.replaceAll(REMOVE_PATTERN, "");
         StringBuilder sb = new StringBuilder(word);
         List<Word> data = inspect(word);
+        /**
+         입력: 과징금 크악 씨  이  빨
+         문자 제거: 과징금크악씨이빨
 
+         기대 결과: 과징금 크악 멍멍
+         실제 결과: 과징금크악멍멍
+
+         **/
         for (int i = data.size() - 1; i >= 0; i--) {
             sb.replace(data.get(i).startIndex(), data.get(i).endIndex(), replace);
         }

--- a/backend/src/main/java/com/meong9/backend/global/banword/util/AhoCorasickWordUtil.java
+++ b/backend/src/main/java/com/meong9/backend/global/banword/util/AhoCorasickWordUtil.java
@@ -7,6 +7,7 @@ import java.util.*;
 public class AhoCorasickWordUtil implements WordUtil {
 
     private final TrieNode root;
+    private static final String REMOVE_PATTERN = "[\\p{N}\\s\\u3164\\p{L}&&[^ㄱ-ㅎ가-힣ㅏ-ㅣa-zA-Z]]";
 
     public AhoCorasickWordUtil() {
         this.root = new TrieNode();
@@ -67,20 +68,30 @@ public class AhoCorasickWordUtil implements WordUtil {
         if (word == null || word.isEmpty()) return result;
         TrieNode node = root;
 
-        int realIndex = 0;
-        int nonSpaceIndex = 0;
+        int realIndex = 0; // 원본 문자열 인덱스
+        int nonSpaceIndex = 0; // 변환된 문자열 인덱스
 
+        // 변환된 문자열 인덱스를 원본 문자열 인덱스와 매핑
         Map<Integer, Integer> startIndices = new HashMap<>();
 
+        // 변환된 문자열 만들기 (제거 규칙 적용)
+        StringBuilder transformed = new StringBuilder();
         for (int i = 0; i < word.length(); i++) {
             char c = word.charAt(i);
 
-            if (Character.isWhitespace(c)) {
-                realIndex++;
-                continue;
+            // REMOVE_PATTERN에 포함되지 않는 문자만 추가
+            if (!String.valueOf(c).matches(REMOVE_PATTERN)) {
+                startIndices.put(nonSpaceIndex, realIndex);
+                transformed.append(c);
+                nonSpaceIndex++;
             }
+            realIndex++;
+        }
 
-            startIndices.put(nonSpaceIndex, realIndex);
+        // 변환된 문자열에서 금칙어 탐지
+        node = root;
+        for (int i = 0; i < transformed.length(); i++) {
+            char c = transformed.charAt(i);
 
             while (node != root && !node.children.containsKey(c)) {
                 node = node.failureLink;
@@ -91,16 +102,16 @@ public class AhoCorasickWordUtil implements WordUtil {
             }
 
             for (String pattern : node.output) {
-                int start = startIndices.getOrDefault(nonSpaceIndex - (pattern.length() - 1), -1);
-                int end = realIndex + 1;
+                int transformedStart = i - (pattern.length() - 1);
+                int start = startIndices.getOrDefault(transformedStart, -1);
+                int end = startIndices.getOrDefault(i, -1) + 1;
 
-                if (start != -1) {
-                    result.add(new Word(pattern, start, end));
+                if (start != -1 && end != -1) {
+                    // 원본 문자열에서 금칙어 텍스트 추출
+                    String originalMatch = word.substring(start, end);
+                    result.add(new Word(originalMatch, start, end));
                 }
             }
-
-            nonSpaceIndex++;
-            realIndex++;
         }
 
         return result;

--- a/backend/src/main/java/com/meong9/backend/global/banword/util/AhoCorasickWordUtil.java
+++ b/backend/src/main/java/com/meong9/backend/global/banword/util/AhoCorasickWordUtil.java
@@ -7,7 +7,7 @@ import java.util.*;
 public class AhoCorasickWordUtil implements WordUtil {
 
     private final TrieNode root;
-    private static final String REMOVE_PATTERN = "[\\p{N}\\s\\u3164\\p{L}&&[^ㄱ-ㅎ가-힣ㅏ-ㅣa-zA-Z]]";
+    private static final String REMOVE_PATTERN = "[\\p{N}\\s\\u3164\\p{L}\\p{P}&&[^ㄱ-ㅎ가-힣ㅏ-ㅣa-zA-Z]]";
 
     public AhoCorasickWordUtil() {
         this.root = new TrieNode();


### PR DESCRIPTION
## 📋 Summary
- 내 리뷰 조회시 reviewId 기준 내림차순 정렬
- 금칙어 우회 작성 차단

## ✨ Feature Details

## 💡 Key Considerations
- 문장에서 금칙어를 찾기 위한 search() 메서드 수정
```java
@Override
public List<Word> search(String word) {
    List<Word> result = new ArrayList<>();
    if (word == null || word.isEmpty()) return result;
    TrieNode node = root;

    int realIndex = 0; // 원본 문자열 인덱스
    int nonSpaceIndex = 0; // 변환된 문자열 인덱스

    // 변환된 문자열 인덱스를 원본 문자열 인덱스와 매핑
    Map<Integer, Integer> startIndices = new HashMap<>();

    // 변환된 문자열 만들기 (제거 규칙 적용)
    StringBuilder transformed = new StringBuilder();
    for (int i = 0; i < word.length(); i++) {
        char c = word.charAt(i);

        // REMOVE_PATTERN에 포함되지 않는 문자만 추가
        if (!String.valueOf(c).matches(REMOVE_PATTERN)) {
            startIndices.put(nonSpaceIndex, realIndex);
            transformed.append(c);
            nonSpaceIndex++;
        }
        realIndex++;
    }

    // 변환된 문자열에서 금칙어 탐지
    node = root;
    for (int i = 0; i < transformed.length(); i++) {
        char c = transformed.charAt(i);

        while (node != root && !node.children.containsKey(c)) {
            node = node.failureLink;
        }

        if (node.children.containsKey(c)) {
            node = node.children.get(c);
        }

        for (String pattern : node.output) {
            int transformedStart = i - (pattern.length() - 1);
            int start = startIndices.getOrDefault(transformedStart, -1);
            int end = startIndices.getOrDefault(i, -1) + 1;

            if (start != -1 && end != -1) {
                // 원본 문자열에서 금칙어 텍스트 추출
                String originalMatch = word.substring(start, end);
                result.add(new Word(originalMatch, start, end));
            }
        }
    }

    return result;
}
```


### 주요 로직
1. 문자 변환 및 인덱스 매핑
- 입력된 문장에서 정해진 문자(공백, 숫자) 제거한 변환된 문자열을 생성하면서, 변환된 문자열의 각 문자 인덱스를 원본 문자열의 인덱스와 매핑
- `startIndices`에 변환된 문자열의 인덱스와 원본 문자열의 인덱스를 저장

2. 금칙어 탐지
- 변환된 문자열에서 금칙어를 탐지
- 탐지된 금칙어의 변환된 문자열 기준 `start`와 `end`를 원본 문자열의 인덱스로 변환

3. 원본 문자열 결과 생성
- 원본 문자열에서 `start`와 `end`를 기준으로 탐지된 금칙어 텍스트를 추출해서 `Word` 객체로 반환

### 예시
- 입력
```plaintext
"과징금 크악 씨12이31빨"
```

- 금칙어
```plaintext
"씨이빨"
```

- 반환 값
```plaintext
Word{word='씨12이31빨', startIndex=7, endIndex=13}
```

## ✅ Checklist
- [x] 코드를 스스로 검토했나요?
- [x] 필요한 테스트를 추가하고 모두 통과했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올렸나요?
- [x] 커밋 메시지가 컨벤션에 맞나요?
- [x] 필요한 문서를 업데이트했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 리뷰 관리 기능 개선: 리뷰 정렬, 저장된 리뷰 로깅, 부적절한 내용 마스킹, 비동기 파일 처리 추가.
	- 리뷰 삭제 시 관련 파일 자동 삭제 기능 추가.
	- 단어 검색 기능 개선을 위한 문자 필터링 및 인덱싱 메커니즘 강화.

- **버그 수정**
	- 리뷰 검색 및 처리 로직 개선으로 인한 효율성 향상.

- **문서화**
	- 입력 및 출력 예시를 포함한 주석 추가로 `BanWordInspector` 클래스 문서화.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->