### PR TITLE
From KAN-106-BE-feat/imageResize into dev : 멤버 블랙리스트 기능 추가

### DIFF
--- a/backend/src/main/java/com/meong9/backend/domain/member/entity/Member.java
+++ b/backend/src/main/java/com/meong9/backend/domain/member/entity/Member.java
@@ -1,6 +1,7 @@
 package com.meong9.backend.domain.member.entity;
 
 import com.meong9.backend.domain.puppy.entity.Puppy;
+import com.meong9.backend.global.blacklist.entity.BlackList;
 import com.meong9.backend.global.entity.BaseTimeEntity;
 import com.meong9.backend.global.mediafile.entity.MediaFile;
 import jakarta.persistence.*;
@@ -53,6 +54,14 @@ public class Member extends BaseTimeEntity {
 
     @Setter
     private LocalDateTime lastActivity = LocalDateTime.now();
+
+    @OneToOne(mappedBy = "member", orphanRemoval = true)
+    @Setter
+    private BlackList blackList;
+
+    @Column
+    @Setter
+    private int badPostCount = 0;
 
     @Builder
     public Member (String email, String name, String provider, String providerId, MediaFile profileImage) {

--- a/backend/src/main/java/com/meong9/backend/domain/member/service/MemberService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/member/service/MemberService.java
@@ -14,6 +14,9 @@ import com.meong9.backend.domain.puppy.repository.PuppyRepository;
 import com.meong9.backend.global.auth.jwt.JwtProvider;
 import com.meong9.backend.global.auth.refreshtoken.RefreshToken;
 import com.meong9.backend.global.auth.refreshtoken.RefreshTokenService;
+import com.meong9.backend.global.blacklist.entity.BlackList;
+import com.meong9.backend.global.blacklist.entity.LockedReason;
+import com.meong9.backend.global.blacklist.repository.BlackListRepository;
 import com.meong9.backend.global.entity.Region;
 import com.meong9.backend.global.exception.AuthenticationException;
 import com.meong9.backend.global.exception.NotFoundException;
@@ -26,6 +29,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -43,6 +47,7 @@ public class MemberService {
     private final RegionRepository regionRepository;
     private final MediaFileService mediaFileService;
     private final PuppyRepository puppyRepository;
+    private final BlackListRepository blackListRepository;
 
     /**
      * refresh token 사용하여 access token 재발급하는 서비스 메서드
@@ -270,5 +275,24 @@ public class MemberService {
         return new InterestDto(favCategoryList.stream()
                 .map(favoritePlace -> favoritePlace.getPlcCategory().getName())
                 .collect(Collectors.toSet()));
+    }
+
+    public void handleBadPost(Member member) {
+        member.setBadPostCount(member.getBadPostCount() + 1);
+
+        // 3번 이상 나쁜 리뷰를 작성하면
+        if (member.getBadPostCount() >= 3) {
+            LocalDateTime lockedUntil = LocalDateTime.now().plusMonths(1);
+            BlackList blackList = BlackList.builder()
+                    .member(member)
+                    .reason(String.valueOf(LockedReason.BADWORDS))
+                    .lockedUntil(lockedUntil)
+                    .build();
+            blackListRepository.save(blackList);
+            member.setBlackList(blackList);
+            member.setBadPostCount(0);
+        }
+
+        memberRepository.save(member);
     }
 }

--- a/backend/src/main/java/com/meong9/backend/domain/review/controller/ReviewController.java
+++ b/backend/src/main/java/com/meong9/backend/domain/review/controller/ReviewController.java
@@ -9,14 +9,12 @@ import com.meong9.backend.global.dto.CommonResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -49,6 +47,10 @@ public class ReviewController {
             @Valid @RequestPart("data") ReviewRequestDto reviewRequestDto,
             @RequestPart(value = "file", required = false) List<MultipartFile> files,
             @CurrentMember Member member)  {
+        // @PreAuthorize로 관리할 경우 403을 반환하기 때문에 200을 반환하되 메시지를 명확히 적어 주도록 함
+        if (member.getBlackList() != null && member.getBlackList().getLockedUntil().isAfter(LocalDateTime.now())) {
+            return CommonResponse.ok("리뷰 작성 권한이 없습니다.");
+        }
         reviewService.createReview(reviewRequestDto,files,member);
         return CommonResponse.created("success");
     }

--- a/backend/src/main/java/com/meong9/backend/domain/review/service/ReviewService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/review/service/ReviewService.java
@@ -126,7 +126,7 @@ public class ReviewService {
         List<MediaFile> mediaFiles = new ArrayList<>();
         Review review = Review.builder()
                 .member(member)
-                .content(banWordInspector.mask(reviewRequestDto.getContent(),"멍멍"))
+                .content(banWordInspector.mask(reviewRequestDto.getContent(),"멍멍", member))
                 .nickname(member.getNickname())
                 .score(reviewRequestDto.getScore())
                 .type(reviewRequestDto.getType())
@@ -171,7 +171,7 @@ public class ReviewService {
         Float oldScore = review.getScore(); // 예전 점수
         Float newScore = reviewRequestDto.getScore(); // 최신 점수
 
-        reviewRequestDto.setContent(banWordInspector.mask(reviewRequestDto.getContent(),"멍멍"));
+        reviewRequestDto.setContent(banWordInspector.mask(reviewRequestDto.getContent(),"멍멍", member));
         review.update(reviewRequestDto);
 
         // 새로운 파일 처리

--- a/backend/src/main/java/com/meong9/backend/domain/search/repository/SearchJooqRepository.java
+++ b/backend/src/main/java/com/meong9/backend/domain/search/repository/SearchJooqRepository.java
@@ -19,7 +19,7 @@ public interface SearchJooqRepository {
     List<Long> findPlaceIdsBySearchWord(String searchWord);
 
     Slice<Long> findPlaceIdsMatchWithCategoryIds(List<Long> firstFilteredPlaceIds, List<Long> categoryIds, String sizeCode, Pageable pageable);
-    Slice<Long> findPensionIdsIsAvailable(List<Long> firstFilteredPensionIds, LocalDate start, LocalDate end, Pageable pageable);
+    Slice<Long> findPensionIdsIsAvailable(List<Long> secondFilteredPensionIds, LocalDate start, LocalDate end, Pageable pageable);
 
-    List<Long> findPensionIdsMatchWithSizeCode(String sizeCode);
+    List<Long> findPensionIdsMatchWithSizeCode(List<Long> firstFilteredPensionIds, String sizeCode);
 }

--- a/backend/src/main/java/com/meong9/backend/domain/search/repository/SearchJooqRepository.java
+++ b/backend/src/main/java/com/meong9/backend/domain/search/repository/SearchJooqRepository.java
@@ -19,5 +19,7 @@ public interface SearchJooqRepository {
     List<Long> findPlaceIdsBySearchWord(String searchWord);
 
     Slice<Long> findPlaceIdsMatchWithCategoryIds(List<Long> firstFilteredPlaceIds, List<Long> categoryIds, String sizeCode, Pageable pageable);
-    Slice<Long> findPensionIdsIsAvailable(List<Long> firstFilteredPensionIds, String sizeCode, LocalDate start, LocalDate end, Pageable pageable);
+    Slice<Long> findPensionIdsIsAvailable(List<Long> firstFilteredPensionIds, LocalDate start, LocalDate end, Pageable pageable);
+
+    List<Long> findPensionIdsMatchWithSizeCode(String sizeCode);
 }

--- a/backend/src/main/java/com/meong9/backend/domain/search/repository/SearchJooqRepositoryImpl.java
+++ b/backend/src/main/java/com/meong9/backend/domain/search/repository/SearchJooqRepositoryImpl.java
@@ -265,18 +265,17 @@ public class SearchJooqRepositoryImpl implements SearchJooqRepository {
     }
 
     @Override
-    public Slice<Long> findPensionIdsIsAvailable(List<Long> firstFilteredPensionIds, String sizeCode, LocalDate start, LocalDate end, Pageable pageable) {
+    public Slice<Long> findPensionIdsIsAvailable(List<Long> secondFilteredPensionIds, LocalDate start, LocalDate end, Pageable pageable) {
 
         List<Long> results =
                 dsl.select(ROOM.PENSION_ID)
                         .from(ROOM)
                         .join(ROOM_AVAILABILITY).on(ROOM.ROOM_ID.eq(ROOM_AVAILABILITY.ROOM_ID))
                         .where(
-                                ROOM.PENSION_ID.in(firstFilteredPensionIds)
+                                ROOM.PENSION_ID.in(secondFilteredPensionIds)
                                 .and(ROOM_AVAILABILITY.DATE.between(start, end))
                                 .and(ROOM_AVAILABILITY.IS_AVAILABLE.isTrue())
                         )
-                        .and(getWeightCondition(PENSION.ENTER_PET_SIZE, sizeCode))
                         .groupBy(ROOM.PENSION_ID)
                         .limit(pageable.getPageSize()+1)
                         .offset((int) pageable.getOffset())
@@ -286,6 +285,15 @@ public class SearchJooqRepositoryImpl implements SearchJooqRepository {
         if (hasNext) results.remove(results.size() - 1);
 
         return new SliceImpl<>(results, pageable, hasNext);
+
+    }
+
+    @Override
+    public List<Long> findPensionIdsMatchWithSizeCode(String sizeCode) {
+        return dsl.select(PENSION.PENSION_ID)
+                        .from(PENSION)
+                        .where(getWeightCondition(PENSION.ENTER_PET_SIZE, sizeCode))
+                        .fetchInto(Long.class);
 
     }
 

--- a/backend/src/main/java/com/meong9/backend/domain/search/repository/SearchJooqRepositoryImpl.java
+++ b/backend/src/main/java/com/meong9/backend/domain/search/repository/SearchJooqRepositoryImpl.java
@@ -289,10 +289,11 @@ public class SearchJooqRepositoryImpl implements SearchJooqRepository {
     }
 
     @Override
-    public List<Long> findPensionIdsMatchWithSizeCode(String sizeCode) {
+    public List<Long> findPensionIdsMatchWithSizeCode(List<Long> firstFilteredPensionIds,String sizeCode) {
         return dsl.select(PENSION.PENSION_ID)
                         .from(PENSION)
-                        .where(getWeightCondition(PENSION.ENTER_PET_SIZE, sizeCode))
+                        .where(PENSION.PENSION_ID.in(firstFilteredPensionIds))
+                        .and(getWeightCondition(PENSION.ENTER_PET_SIZE, sizeCode))
                         .fetchInto(Long.class);
 
     }

--- a/backend/src/main/java/com/meong9/backend/domain/search/service/SearchService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/search/service/SearchService.java
@@ -113,17 +113,18 @@ public class SearchService {
 
         // 2. 반려견 체중 조건 추가
         String sizeCode = heaviestDogWeight < 10 ? "010" : heaviestDogWeight < 25 ? "020" : "030";
+        List<Long> secondFilteredPlaceIds = searchRepository.findPensionIdsMatchWithSizeCode(sizeCode);
 
         LocalDate start = LocalDate.parse(startDate);
         LocalDate end = LocalDate.parse(endDate);
 
         // 3. 최종 필터링된 펜션ID 조회
-        Slice<Long> secondFilteredPlaceIds = searchRepository.findPensionIdsIsAvailable(firstFilteredPensionIds, sizeCode, start, end, pageable);
+        Slice<Long> thirdFilteredPlaceIds = searchRepository.findPensionIdsIsAvailable(secondFilteredPlaceIds, start, end, pageable);
 
         // 4. pendionId를 가지고 정보 조회
         List<SearchPensionDto> filteredPensions =
                 searchRepository.searchPensions(
-                        secondFilteredPlaceIds.getContent(),
+                        thirdFilteredPlaceIds.getContent(),
                         startDate,
                         endDate,
                         sizeCode,
@@ -131,6 +132,6 @@ public class SearchService {
                         memberId);
 
         // 4. 반환
-        return new SearchPensionsResponseDto(filteredPensions, secondFilteredPlaceIds.hasNext());
+        return new SearchPensionsResponseDto(filteredPensions, thirdFilteredPlaceIds.hasNext());
     }
 }

--- a/backend/src/main/java/com/meong9/backend/domain/search/service/SearchService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/search/service/SearchService.java
@@ -113,7 +113,7 @@ public class SearchService {
 
         // 2. 반려견 체중 조건 추가
         String sizeCode = heaviestDogWeight < 10 ? "010" : heaviestDogWeight < 25 ? "020" : "030";
-        List<Long> secondFilteredPlaceIds = searchRepository.findPensionIdsMatchWithSizeCode(sizeCode);
+        List<Long> secondFilteredPlaceIds = searchRepository.findPensionIdsMatchWithSizeCode(firstFilteredPensionIds, sizeCode);
 
         LocalDate start = LocalDate.parse(startDate);
         LocalDate end = LocalDate.parse(endDate);

--- a/backend/src/main/java/com/meong9/backend/global/auth/entity/MemberDetails.java
+++ b/backend/src/main/java/com/meong9/backend/global/auth/entity/MemberDetails.java
@@ -6,6 +6,7 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
+import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.Collections;
 
@@ -35,7 +36,9 @@ public record MemberDetails (Member member) implements UserDetails {
 
     @Override
     public boolean isAccountNonLocked() {
-        return true;
+        return member.getBlackList() == null || // 블랙리스트에 등록된 적도 없을 때
+                member.getBlackList().getLockedUntil() == null || // 블랙 리스트에 등록되었지만 기간이 등록되어 있지 않을 때
+                member.getBlackList().getLockedUntil().isBefore(LocalDateTime.now()); // 블랙 리스트 기간이 지났을 때
     }
 
     @Override

--- a/backend/src/main/java/com/meong9/backend/global/banword/inspector/BanWordInspector.java
+++ b/backend/src/main/java/com/meong9/backend/global/banword/inspector/BanWordInspector.java
@@ -1,9 +1,11 @@
 package com.meong9.backend.global.banword.inspector;
 
-import com.meong9.backend.global.banword.domain.Word;
+import com.meong9.backend.domain.member.entity.Member;
+import com.meong9.backend.domain.member.service.MemberService;
 import com.meong9.backend.global.banword.config.InspectorConfig;
-import com.meong9.backend.global.banword.manager.ExceptWordManager;
+import com.meong9.backend.global.banword.domain.Word;
 import com.meong9.backend.global.banword.manager.BanWordManager;
+import com.meong9.backend.global.banword.manager.ExceptWordManager;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -15,12 +17,15 @@ import java.util.List;
 public class BanWordInspector {
     private final BanWordManager banWordManager;
     private final ExceptWordManager exceptWordManager;
+    private final MemberService memberService;
+
     private static final String REMOVE_PATTERN = "[\\p{N}\\s\\u3164\\p{L}&&[^ㄱ-ㅎ가-힣ㅏ-ㅣa-zA-Z]]";
 
     @Autowired
-    public BanWordInspector(InspectorConfig config) {
+    public BanWordInspector(InspectorConfig config, MemberService memberService) {
         banWordManager = config.getBanWordUtil();
         exceptWordManager = config.getExceptWordUtil();
+        this.memberService = memberService;
     }
 
     private List<Word> executeBanWord(String word) {
@@ -35,13 +40,17 @@ public class BanWordInspector {
         return executeExceptWord(word, executeBanWord(word));
     }
 
-    public String mask(String word) {
-        return mask(word,"어머");
+    public String mask(String word, Member member) {
+        return mask(word,"어머", member);
     }
 
-    public String mask(String word, String replace) {
+    public String mask(String word, String replace, Member member) {
         StringBuilder sb = new StringBuilder(word);
         List<Word> data = inspect(word);
+
+        if (!data.isEmpty()) {
+            memberService.handleBadPost(member);
+        }
 
         /**
          입력: 과징금 크악 씨  이  빨

--- a/backend/src/main/java/com/meong9/backend/global/blacklist/entity/BlackList.java
+++ b/backend/src/main/java/com/meong9/backend/global/blacklist/entity/BlackList.java
@@ -1,0 +1,36 @@
+package com.meong9.backend.global.blacklist.entity;
+
+import com.meong9.backend.domain.member.entity.Member;
+import com.meong9.backend.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+public class BlackList extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long blackListId;
+
+    @OneToOne
+    @JoinColumn(name = "member_id", nullable = false, unique = true)
+    private Member member;
+
+    @Column(name = "reason")
+    private String reason;
+
+    @Column(name = "locked_until")
+    private LocalDateTime lockedUntil;
+
+    @Builder
+    public BlackList(Member member, String reason, LocalDateTime lockedUntil) {
+        this.member = member;
+        this.reason = reason;
+        this.lockedUntil = lockedUntil;
+    }
+}

--- a/backend/src/main/java/com/meong9/backend/global/blacklist/entity/LockedReason.java
+++ b/backend/src/main/java/com/meong9/backend/global/blacklist/entity/LockedReason.java
@@ -1,0 +1,5 @@
+package com.meong9.backend.global.blacklist.entity;
+
+public enum LockedReason {
+    BADWORDS
+}

--- a/backend/src/main/java/com/meong9/backend/global/blacklist/repository/BlackListRepository.java
+++ b/backend/src/main/java/com/meong9/backend/global/blacklist/repository/BlackListRepository.java
@@ -1,0 +1,12 @@
+package com.meong9.backend.global.blacklist.repository;
+
+import com.meong9.backend.global.blacklist.entity.BlackList;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface BlackListRepository extends JpaRepository<BlackList, Long> {
+
+    List<BlackList> findAllByLockedUntilBefore(LocalDateTime now);
+}

--- a/backend/src/main/java/com/meong9/backend/global/blacklist/scheduler/BlackListScheduler.java
+++ b/backend/src/main/java/com/meong9/backend/global/blacklist/scheduler/BlackListScheduler.java
@@ -1,0 +1,39 @@
+package com.meong9.backend.global.blacklist.scheduler;
+
+import com.meong9.backend.domain.member.entity.Member;
+import com.meong9.backend.global.blacklist.entity.BlackList;
+import com.meong9.backend.global.blacklist.repository.BlackListRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Component
+@EnableScheduling
+@Slf4j
+@RequiredArgsConstructor
+public class BlackListScheduler {
+
+    private final BlackListRepository blackListRepository;
+
+    @Scheduled(cron = "0 0 0 * * ?") // 매일 자정 실행
+    public void removeExpiredBlackLists() {
+        List<BlackList> expiredBlackLists = blackListRepository.findAllByLockedUntilBefore(LocalDateTime.now());
+
+        if (!expiredBlackLists.isEmpty()) {
+            // BlackList 삭제 전에 Member에서 연결 해제
+            expiredBlackLists.forEach(blackList -> {
+                Member member = blackList.getMember();
+                if (member != null) {
+                    member.setBlackList(null);
+                }
+            });
+
+            blackListRepository.deleteAllInBatch(expiredBlackLists);
+        }
+    }
+}


### PR DESCRIPTION
## 📋 Summary
<!-- 이 PR에서 변경된 주요 내용을 간략히 작성해주세요. -->
- 멤버 블랙리스트 기능 추가
- 펜션 검색 시, 반려견 체중 조건이 반영되지 않는 문제 수정. 

## ✨ Feature Details
| Method | Path                      | Description      |
|--------|---------------------------|------------------|


## 💡 Key Considerations
<!-- 구현하면서 고려한 점, 또는 해결한 주요 이슈를 간단히 작성해주세요. -->
1. 3번 이상 비속어 사용 리뷰를 작성하면 -> 블랙리스트에 올라 1달 간 리뷰 작성을 못하도록 함
- Member에 bad_post_count를 추가하여 비속어 리뷰를 작성할 때마다 +1
- 로그인 시 해당 멤버의 블랙리스트 여부를 확인하여 isAccountNonLocked 여부를 판단하여 객체 생성 -> 리뷰 작성 시 확인
- @PreAuthorize 어노테이션으로 관리할 경우 무조건 403을 반환하며, 이를 핸들러로 관리할 경우 다른 403까지 전역적으로 포함되기 때문에, 컨트롤러에서 200과 함께 리뷰 작성 권한이 없음을 알리는 메시지를 반환하도록 함. 
- 기간이 지난 블랙리스트는 매일 12시 스케쥴러로 deleteAllInBatch를 사용하여 제거
- Locked Reason 이넘을 두어, 다른 블랙리스트 연유가 생길 때 사용 가능하도록 함. 

## ✅ Checklist
- [X] 코드를 스스로 검토했나요?
- [X] 필요한 테스트를 추가하고 모두 통과했나요?
- [ ] 브랜치 전략에 맞는 브랜치에 PR을 올렸나요?
- [X] 커밋 메시지가 컨벤션에 맞나요?
- [ ] 필요한 문서를 업데이트했나요? (프론트에 해당 내용 이야기해야)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 회원의 블랙리스트 관리 기능 추가.
  - 게시물의 부적절한 내용 감지 시 회원의 게시물 카운트 증가 및 블랙리스트 등록.
  - 블랙리스트 만료 관리 기능 추가.
  - 특정 사이즈 코드에 따라 연금 ID 필터링 기능 추가.

- **버그 수정**
  - 블랙리스트 상태에 따라 리뷰 생성 권한 체크 로직 개선.
  - 메서드 이름 수정으로 HTTP DELETE 요청에 대한 명확성 향상.

- **문서화**
  - 새로운 `BlackList` 클래스 및 `LockedReason` 열거형 추가. 

- **기타**
  - 블랙리스트 관련 레포지토리 및 스케줄러 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->