### PR TITLE
From KAN-117-BE-API-refactor/weather into dev : 스케줄러 2번 수행 및 요청 날짜 정보 수정

### DIFF
--- a/backend/src/main/java/com/meong9/backend/domain/weather/service/WeatherApiService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/weather/service/WeatherApiService.java
@@ -21,12 +21,12 @@ public class WeatherApiService {
     private String weatherKey; // 서비스 키
 
     // 단기 예보
-    public String getWeatherForecastST(String[] xy, String date) {
+    public String getWeatherForecastST(String[] xy, String date, String time) {
         try {
             // URL 포맷 지정
             String url = String.format(
-                    "http://apis.data.go.kr/1360000/VilageFcstInfoService_2.0/getVilageFcst?serviceKey=%s&pageNo=1&numOfRows=798&dataType=JSON&base_date=%s&base_time=1400&nx=%s&ny=%s",
-                    weatherKey, date, xy[0], xy[1]
+                    "http://apis.data.go.kr/1360000/VilageFcstInfoService_2.0/getVilageFcst?serviceKey=%s&pageNo=1&numOfRows=798&dataType=JSON&base_date=%s&base_time=%s&nx=%s&ny=%s",
+                    weatherKey, date, time, xy[0], xy[1]
             );
 
             // WebClient 호출
@@ -55,7 +55,6 @@ public class WeatherApiService {
                     "http://apis.data.go.kr/1360000/MidFcstInfoService/getMidLandFcst?serviceKey=%s&pageNo=1&numOfRows=10&dataType=JSON&regId=%s&tmFc=%s",
                     weatherKey, code, date
             );
-
             // WebClient 호출
             String responseBody = webClient.get()
                     .uri(URI.create(url)) // 자동 인코딩 방지

--- a/backend/src/main/java/com/meong9/backend/domain/weather/service/WeatherService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/weather/service/WeatherService.java
@@ -20,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
@@ -33,13 +34,15 @@ public class WeatherService {
     private static final String WEATHER_KEY = "weather:";
     private static final DateTimeFormatter FULL_DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMddHHmm");
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
+    private static final DateTimeFormatter FULL_DATE_TIME_FORMATTER_ST = DateTimeFormatter.ofPattern("HHmm");
+
 
     private final RedisTemplate<String, Object> redisTemplate;
     private final ObjectMapper objectMapper;
     private final WeatherApiService weatherApiService;
 
     // 지역 별 날씨 데이터 (기상청  api 호출)
-    @Scheduled(cron = "0 0 6 * * ?") // 새벽 6시
+    @Scheduled(cron = "0 0 6,18 * * ?")// 새벽 6시, 저녁 6시
 //    @Scheduled(cron = "0 * * * * ?")
     public void fetchAndStoreWeatherData() {
         for (Map.Entry<String, String> entry : RegionMapper.getWeatherRegionAll().entrySet()) {
@@ -65,6 +68,8 @@ public class WeatherService {
             weatherDto.setRegionName(region);
 
             return weatherDto;
+        } catch (NotFoundException e){
+            throw NotFoundException.entityNotFound("날씨 데이터");
         } catch (JsonProcessingException e) {
             // json 파싱 오류
             throw InternalServerError.parseJsonError(e.getMessage());
@@ -82,28 +87,35 @@ public class WeatherService {
         int attempt = 0;
         while (attempt < maxRetries) {
             try {
-                processRegionWeather(regionKey, regionValue); // 지역 날씨 처리
+                LocalTime now = LocalTime.now();
+                int hour = now.getHour();
+
+                processRegionWeather(regionKey, regionValue, hour); // 지역 날씨 처리
                 return; // 성공 시 메서드 종료
             } catch (Exception e) {
                 attempt++;
                 log.info(String.format("지역 처리 실패: %s (%d/%d 시도)", regionKey, attempt, maxRetries));
                 if (attempt >= maxRetries) {
                     log.error("최대 재시도 횟수 초과: " + regionKey);
-                    throw InternalServerError.schedulerFailError(e.getMessage());
+                    log.error("날씨 데이터를 저장하지 않고 종료합니다.");
+
+                    return;
                 }
             }
         }
     }
 
     // 날씨 데이터 처리
-    private void processRegionWeather(String region, String code) {
-        String dateFormatMid = getFixedTime(6, 0).format(FULL_DATE_TIME_FORMATTER);
-        String dateFormatST = getYesterday().format(DATE_FORMATTER);
+    private void processRegionWeather(String region, String code, int hour) {
+        String dateFormatMid = getFixedTime(hour, 0).format(FULL_DATE_TIME_FORMATTER);
+
+        String timeFormat = getFixedTime(hour - 1, 0).format(FULL_DATE_TIME_FORMATTER_ST);
+        String dateFormatST = getToday().format(DATE_FORMATTER);
 
         String[] xy = RegionMapper.getWeatherXYRegion(region);
 
         String responseMid = weatherApiService.getWeatherForecastMid(code, dateFormatMid);
-        String responseST = weatherApiService.getWeatherForecastST(xy, dateFormatST);
+        String responseST = weatherApiService.getWeatherForecastST(xy, dateFormatST, timeFormat);
 
         // 단기
         List<String> weatherCodes = parseShortTermWeather(responseST);
@@ -215,7 +227,7 @@ public class WeatherService {
         return LocalDateTime.now().withHour(hour).withMinute(minute);
     }
 
-    private LocalDate getYesterday() {
-        return LocalDate.now().minusDays(1);
+    private LocalDate getToday() {
+        return LocalDate.now();
     }
 }


### PR DESCRIPTION
## 📋 Summary
<!-- 이 PR에서 변경된 주요 내용을 간략히 작성해주세요. -->
기상청 API에서 날씨 정보가 변경될 것을 생각해 하루 2번 스케줄러 실행으로 변경


## ✨ Feature Details
| Method | Path                      | Description      |
|--------|---------------------------|------------------|


## 💡 Key Considerations
<!-- 구현하면서 고려한 점, 또는 해결한 주요 이슈를 간단히 작성해주세요. -->
기상청 API에서 날씨 정보가 변경될 것을 생각해 하루 2번 스케줄러 실행으로 변경
스케줄러 실행 시간은 오전 6시, 오후 6시에 실행되고, 
중기 요청 시간은 당일 06시, 당일 18시
단기 요청 시간은 당일 05시, 당일 17시에 발표된 것을 기준으로 당일~10일까지의 오후 3시 날씨 정보를 가져오게 됨.
매 시간 기상청 API 응답이 있는 게 아니라 조금 까다롭다...

## ✅ Checklist
- [ ] 코드를 스스로 검토했나요?
- [ ] 필요한 테스트를 추가하고 모두 통과했나요?
- [ ] 브랜치 전략에 맞는 브랜치에 PR을 올렸나요?
- [ ] 커밋 메시지가 컨벤션에 맞나요?
- [ ] 필요한 문서를 업데이트했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 날씨 예보 API 호출 시 동적 시간 파라미터 추가.
	- 날씨 데이터 수집 주기를 오전 6시 및 오후 6시로 변경.

- **버그 수정**
	- 날씨 데이터 미발견 시 구체적인 오류 메시지 제공.
	- 최대 재시도 횟수 초과 시 오류 메시지 로그 기록.

- **기타 변경 사항**
	- `getYesterday` 메서드 제거 및 `getToday`로 대체.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->