### PR TITLE
From KAN-121-BE-feat/presignedUrl-api into dev: 리뷰 이미지/영상 업로드를 위한 presigned url 발급 요청 api 추가

### DIFF
--- a/backend/src/main/java/com/meong9/backend/domain/review/controller/ReviewController.java
+++ b/backend/src/main/java/com/meong9/backend/domain/review/controller/ReviewController.java
@@ -1,11 +1,14 @@
 package com.meong9.backend.domain.review.controller;
 
 import com.meong9.backend.domain.member.entity.Member;
+import com.meong9.backend.domain.review.dto.PresignedUrlDto;
 import com.meong9.backend.domain.review.dto.ReviewMainDto;
 import com.meong9.backend.domain.review.dto.ReviewRequestDto;
+import com.meong9.backend.domain.review.dto.ReviewUrlRequestDto;
 import com.meong9.backend.domain.review.service.ReviewService;
 import com.meong9.backend.global.annotation.member.CurrentMember;
 import com.meong9.backend.global.dto.CommonResponse;
+import com.meong9.backend.global.mediafile.service.MediaFileService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -27,6 +30,7 @@ import java.util.concurrent.TimeoutException;
 @Slf4j
 public class ReviewController {
     private final ReviewService reviewService;
+    private final MediaFileService mediaFileService;
 
     @GetMapping("/reviews/{reviewId}")
     public ResponseEntity<?> getReviewDetails(@PathVariable Long reviewId) {
@@ -41,6 +45,12 @@ public class ReviewController {
     @GetMapping("/reviews/info")
     public ResponseEntity<?> getPlacePensionInfo(@RequestParam(required = true) String type,@RequestParam(required = true) Long id) {
         return CommonResponse.ok("success", reviewService.getPlacePensionInfo(type,id));
+    }
+
+    @PostMapping("/reviews/presigned-url")
+    public ResponseEntity<?> getPresignedUrlForReview(@RequestBody ReviewUrlRequestDto reviewUrlRequestDto) {
+        List<PresignedUrlDto> presignedUrls = mediaFileService.getPresignedUrlForReview(reviewUrlRequestDto);
+        return ResponseEntity.ok(presignedUrls);
     }
 
     @PostMapping("/reviews")

--- a/backend/src/main/java/com/meong9/backend/domain/review/dto/PresignedUrlDto.java
+++ b/backend/src/main/java/com/meong9/backend/domain/review/dto/PresignedUrlDto.java
@@ -1,0 +1,13 @@
+package com.meong9.backend.domain.review.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+@AllArgsConstructor
+public class PresignedUrlDto {
+    private String fileName;
+    private String url;
+}

--- a/backend/src/main/java/com/meong9/backend/domain/review/dto/ReviewUrlRequestDto.java
+++ b/backend/src/main/java/com/meong9/backend/domain/review/dto/ReviewUrlRequestDto.java
@@ -1,0 +1,16 @@
+package com.meong9.backend.domain.review.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReviewUrlRequestDto {
+    private Long plcPenId;
+    private String type;
+    private List<String> files;
+}

--- a/backend/src/main/java/com/meong9/backend/global/auth/config/SecurityConfig.java
+++ b/backend/src/main/java/com/meong9/backend/global/auth/config/SecurityConfig.java
@@ -63,6 +63,7 @@ public class SecurityConfig {
         // 필터링에서 제외할 요청들
         final RequestMatcher ignoredRequests = new OrRequestMatcher(
                 List.of(new AntPathRequestMatcher("/api/v1/auth/callback/kakao", HttpMethod.GET.name()),
+                        new AntPathRequestMatcher("/api/v1/auth/token", HttpMethod.POST.name()),
                         new AntPathRequestMatcher("/api/v1/members/check", HttpMethod.GET.name()),
                         new AntPathRequestMatcher("/api/v1/spots/rankings", HttpMethod.GET.name()),
                         new AntPathRequestMatcher("/api/v1/spots/reviews", HttpMethod.GET.name()),

--- a/backend/src/main/java/com/meong9/backend/global/mediafile/service/MediaFileService.java
+++ b/backend/src/main/java/com/meong9/backend/global/mediafile/service/MediaFileService.java
@@ -5,6 +5,8 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.meong9.backend.domain.review.dto.PresignedUrlDto;
+import com.meong9.backend.domain.review.dto.ReviewUrlRequestDto;
 import com.meong9.backend.global.exception.BadRequestException;
 import com.meong9.backend.global.mediafile.dto.ImageMetadataDto;
 import com.meong9.backend.global.mediafile.dto.S3UploadResultDto;
@@ -34,6 +36,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -402,5 +405,24 @@ public class MediaFileService {
         response.put("presignedUrl", presignedUrl);
         response.put("fileKey", objectKey); // 파일 경로
         return response;
+    }
+
+    public List<PresignedUrlDto> getPresignedUrlForReview(ReviewUrlRequestDto requestDto) {
+        return requestDto.getFiles().stream()
+                .map(fileName -> {
+                    URL presignedUrl = generatePresignedUrl(fileName);
+                    return new PresignedUrlDto(fileName, presignedUrl.toString());
+                })
+                .collect(Collectors.toList());
+    }
+
+    private URL generatePresignedUrl(String objectKey) {
+        // Presigned URL 생성 요청
+        GeneratePresignedUrlRequest presignedUrlRequest = new GeneratePresignedUrlRequest(bucket, objectKey)
+                .withMethod(HttpMethod.PUT)
+                .withExpiration(new Date(System.currentTimeMillis() + 15 * 60 * 1000)); // 15분 유효
+
+        // Presigned URL 생성 및 반환
+        return amazonS3.generatePresignedUrl(presignedUrlRequest);
     }
 }


### PR DESCRIPTION
## 📋 Summary
<!-- 이 PR에서 변경된 주요 내용을 간략히 작성해주세요. -->
- 리뷰 이미지/영상 업로드를 위한 presigned url 발급 요청 api 추가

## ✨ Feature Details
| Method | Path                      | Description      |
|--------|---------------------------|------------------|
| POST   | /api/v1/reviews/presigned-url | presigned url 요청        |


## 💡 Key Considerations
<!-- 구현하면서 고려한 점, 또는 해결한 주요 이슈를 간단히 작성해주세요. -->
- 이미지 / 영상 처리 개편 시작. 전체적인 흐름은 노션에 정리해 두었음. 
[노션 보러가기](https://cake-ozraraptor-0a4.notion.site/62c0eef032f14f3ead9c08aeb0d21a8d?pvs=4)

![image](https://github.com/user-attachments/assets/8bde8a9c-873e-4c06-bf4c-caa45c18214a)

## ✅ Checklist
- [X] 코드를 스스로 검토했나요?
- [X] 필요한 테스트를 추가하고 모두 통과했나요?
- [X] 브랜치 전략에 맞는 브랜치에 PR을 올렸나요?
- [X] 커밋 메시지가 컨벤션에 맞나요?
- [X] 필요한 문서를 업데이트했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 리뷰 파일 업로드를 위한 사전 서명된 URL 생성 기능 추가
	- 여러 파일에 대한 동시 URL 요청 지원

- **개선 사항**
	- 리뷰 관련 미디어 파일 처리 메커니즘 강화
	- 파일 업로드 프로세스의 보안 및 효율성 향상
	- 인증 없이 `/api/v1/auth/token` 엔드포인트에 대한 POST 요청 허용
<!-- end of auto-generated comment: release notes by coderabbit.ai -->