### PR TITLE
Kan 118 be feat/recommendation alarm into dev : 알림 전송 방식 변경

### DIFF
--- a/backend/src/main/java/com/meong9/backend/domain/alarm/FcmMessage.java
+++ b/backend/src/main/java/com/meong9/backend/domain/alarm/FcmMessage.java
@@ -3,6 +3,7 @@ package com.meong9.backend.domain.alarm;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import java.util.Map;
 
 @Builder
 @AllArgsConstructor
@@ -15,31 +16,7 @@ public class FcmMessage {
     @AllArgsConstructor
     @Getter
     public static class Message {
-        private Notification notification;
-        private String token;
-        private WebPush webpush;
-    }
-
-    @Builder
-    @AllArgsConstructor
-    @Getter
-    public static class Notification {
-        private String title;
-        private String body;
-        private String image;
-    }
-
-    @Builder
-    @AllArgsConstructor
-    @Getter
-    public static class WebPush {
-        private WebpushFcmOptions fcmOptions;
-    }
-
-    @Builder
-    @AllArgsConstructor
-    @Getter
-    public static class WebpushFcmOptions {
-        private String link;
+        private Map<String, String> data;  // data 필드를 추가하여 알림 데이터를 Map 형태로 전달
+        private String token;              // FCM 토큰
     }
 }

--- a/backend/src/main/java/com/meong9/backend/domain/alarm/service/FcmService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/alarm/service/FcmService.java
@@ -150,18 +150,11 @@ public class FcmService {
         FcmMessage fcmMessage = FcmMessage.builder()
                 .message(FcmMessage.Message.builder()
                         .token(targetToken)
-                        .notification(FcmMessage.Notification.builder()
-                                .title(title)
-                                .body(body)
-                                .image(null)
-                                .build()
-                        )
-                        .webpush(FcmMessage.WebPush.builder()
-                                .fcmOptions(FcmMessage.WebpushFcmOptions.builder()
-                                        .link("https://mungtivity.vercel.app")
-                                        .build())
-                                .build())
-                        .build())
+                        .data(Map.of(
+                                "title", title,
+                                "body", body,
+                                "url", "https://mungtivity.vercel.app"
+                        )).build())
                 .validateOnly(false).build();
 
         return objectMapper.writeValueAsString(fcmMessage);
@@ -205,7 +198,7 @@ public class FcmService {
     }
 
     // 토큰 삭제
-    private void deleteToken(String key) {
+    public void deleteToken(String key) {
         redisTemplate.delete(key);
     }
 

--- a/backend/src/main/java/com/meong9/backend/domain/member/service/MemberService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/member/service/MemberService.java
@@ -1,5 +1,6 @@
 package com.meong9.backend.domain.member.service;
 
+import com.meong9.backend.domain.alarm.service.FcmService;
 import com.meong9.backend.domain.member.dto.*;
 import com.meong9.backend.domain.member.entity.FavoriteRegion;
 import com.meong9.backend.domain.member.entity.Member;
@@ -11,6 +12,7 @@ import com.meong9.backend.domain.place.entity.PlcCategory;
 import com.meong9.backend.domain.place.repository.PlcCategoryRepository;
 import com.meong9.backend.domain.puppy.entity.Puppy;
 import com.meong9.backend.domain.puppy.repository.PuppyRepository;
+import com.meong9.backend.global.auth.entity.MemberDetails;
 import com.meong9.backend.global.auth.jwt.JwtProvider;
 import com.meong9.backend.global.auth.refreshtoken.RefreshToken;
 import com.meong9.backend.global.auth.refreshtoken.RefreshTokenService;
@@ -24,6 +26,8 @@ import com.meong9.backend.global.mediafile.service.MediaFileService;
 import com.meong9.backend.global.repository.RegionRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -48,6 +52,7 @@ public class MemberService {
     private final MediaFileService mediaFileService;
     private final PuppyRepository puppyRepository;
     private final BlackListRepository blackListRepository;
+    private final FcmService fcmService;
 
     /**
      * refresh token 사용하여 access token 재발급하는 서비스 메서드
@@ -83,9 +88,13 @@ public class MemberService {
         if (refreshToken == null) {
             throw AuthenticationException.noRefreshToken();
         }
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Long memberId = ((MemberDetails) authentication.getPrincipal()).member().getMemberId();
 
         jwtProvider.validateToken(refreshToken);
         refreshTokenService.removeRefreshTokenByKeyEmail(jwtProvider.getSubjectFromToken(refreshToken));
+
+        fcmService.deleteToken("fcm_token:" + memberId);
     }
 
     /**

--- a/backend/src/main/java/com/meong9/backend/domain/member/service/MemberService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/member/service/MemberService.java
@@ -89,6 +89,9 @@ public class MemberService {
             throw AuthenticationException.noRefreshToken();
         }
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (!(authentication.getPrincipal() instanceof MemberDetails)) {
+            throw new AuthenticationException("잘못된 인증 정보입니다.");
+        }
         Long memberId = ((MemberDetails) authentication.getPrincipal()).member().getMemberId();
 
         jwtProvider.validateToken(refreshToken);


### PR DESCRIPTION
## 📋 Summary
<!-- 이 PR에서 변경된 주요 내용을 간략히 작성해주세요. -->
백엔드에서 notification에서 data로 정보만 주게 수정하면서 알림 생성을 프론트 서비스워커에서 처리하게 수정
로그아웃 시 fcm 토큰 삭제

## ✨ Feature Details
| Method | Path                      | Description      |
|--------|---------------------------|------------------|



## 💡 Key Considerations
<!-- 구현하면서 고려한 점, 또는 해결한 주요 이슈를 간단히 작성해주세요. -->


## ✅ Checklist
- [ ] 코드를 스스로 검토했나요?
- [ ] 필요한 테스트를 추가하고 모두 통과했나요?
- [ ] 브랜치 전략에 맞는 브랜치에 PR을 올렸나요?
- [ ] 커밋 메시지가 컨벤션에 맞나요?
- [ ] 필요한 문서를 업데이트했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- Firebase Cloud Messaging (FCM) 메시지 구조 간소화
	- 로그아웃 시 FCM 토큰 자동 삭제 기능 추가

- **개선 사항**
	- 알림 페이로드 데이터 전송 방식 변경
	- 메시지 구성 로직 최적화
	- FCM 서비스와의 통합으로 멤버 서비스 기능 향상

- **기타 변경 사항**
	- 멤버 서비스의 토큰 관리 기능 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->