### PR TITLE
From KAN-121-BE-feat/presignedUrl-api  into dev : 내 후기 조회, 삭제 수정

### DIFF
--- a/backend/src/main/java/com/meong9/backend/domain/review/controller/ReviewController.java
+++ b/backend/src/main/java/com/meong9/backend/domain/review/controller/ReviewController.java
@@ -73,7 +73,7 @@ public class ReviewController {
             @PathVariable Long reviewId,
             @Valid @RequestPart("data") ReviewRequestDto reviewRequestDto,
             @RequestPart(value = "file", required = false) List<MultipartFile> newFiles,
-            @CurrentMember Member member) throws IOException, IllegalAccessException, InterruptedException, TimeoutException {
+            @CurrentMember Member member) {
         reviewService.updateReview(reviewId, reviewRequestDto, newFiles, member);
         return CommonResponse.ok("success");
     }

--- a/backend/src/main/java/com/meong9/backend/domain/review/controller/ReviewController.java
+++ b/backend/src/main/java/com/meong9/backend/domain/review/controller/ReviewController.java
@@ -81,8 +81,7 @@ public class ReviewController {
 
     @DeleteMapping("/reviews/{reviewId}")
     public ResponseEntity<?> deleteReview(
-            @PathVariable Long reviewId,
-            @CurrentMember Member member) throws IllegalAccessException {
+            @PathVariable Long reviewId, @CurrentMember Member member) {
         reviewService.deleteReview(reviewId, member);
         return CommonResponse.ok("success");
     }

--- a/backend/src/main/java/com/meong9/backend/domain/review/dto/FileResponseDto.java
+++ b/backend/src/main/java/com/meong9/backend/domain/review/dto/FileResponseDto.java
@@ -3,15 +3,17 @@ package com.meong9.backend.domain.review.dto;
 import com.meong9.backend.domain.review.entity.ReviewFile;
 import com.meong9.backend.global.mediafile.entity.FileType;
 import com.meong9.backend.global.mediafile.entity.MediaFile;
-import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class FileResponseDto {
-    private final FileType fileType;
-    private final Integer fileSize;
-    private final String fileUrl;
-    private final String fileName;
+    private Long reviewId;
+    private FileType fileType;
+    private Integer fileSize;
+    private String fileUrl;
+    private String fileName;
 
     public FileResponseDto(ReviewFile reviewFile) {
         MediaFile file = reviewFile.getFile();
@@ -21,7 +23,8 @@ public class FileResponseDto {
         this.fileName = file.getFileName();
     }
 
-    public FileResponseDto(FileType fileType, Integer fileSize, String fileUrl, String fileName) {
+    public FileResponseDto(Long reviewId, FileType fileType, Integer fileSize, String fileUrl, String fileName) {
+        this.reviewId = reviewId;
         this.fileType = fileType;
         this.fileSize = fileSize;
         this.fileUrl = fileUrl;

--- a/backend/src/main/java/com/meong9/backend/domain/review/dto/MyReviewResponseDto.java
+++ b/backend/src/main/java/com/meong9/backend/domain/review/dto/MyReviewResponseDto.java
@@ -1,32 +1,28 @@
 package com.meong9.backend.domain.review.dto;
 
-import com.meong9.backend.domain.review.entity.Review;
-import com.meong9.backend.domain.review.entity.ReviewFile;
-import com.meong9.backend.global.mediafile.entity.FileType;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.time.LocalDate;
-import java.util.Date;
 import java.util.List;
 
 @Getter
+@NoArgsConstructor
 public class MyReviewResponseDto {
-    private final Long reviewId;
-    private final String content;
-    private final Float score;
-    private final LocalDate visitDate;
-    private final FileResponseDto file;
-    private final String type;
-    private final Long plcPenId;
-    private final String plcPenName;
-    private final String nickname;
+    private Long reviewId;
+    private String content;
+    private Float score;
+    private LocalDate visitDate;
+    @Setter
+    private List<FileResponseDto> file;
+    private String type;
+    private Long plcPenId;
+    private String plcPenName;
+    private String nickname;
 
     public MyReviewResponseDto(Long reviewId, String content, Float score, LocalDate visitDate,
-                               String type, Long plcPenId, String plcPenName, String nickname,
-                               FileResponseDto file) {
+                               String type, Long plcPenId, String plcPenName, String nickname) {
         this.reviewId = reviewId;
         this.content = content;
         this.score = score;
@@ -35,6 +31,5 @@ public class MyReviewResponseDto {
         this.plcPenId = plcPenId;
         this.plcPenName = plcPenName;
         this.nickname = nickname;
-        this.file=file;
     }
 }

--- a/backend/src/main/java/com/meong9/backend/domain/review/repository/ReviewFileRepository.java
+++ b/backend/src/main/java/com/meong9/backend/domain/review/repository/ReviewFileRepository.java
@@ -1,5 +1,6 @@
 package com.meong9.backend.domain.review.repository;
 
+import com.meong9.backend.domain.review.dto.FileResponseDto;
 import com.meong9.backend.domain.review.entity.Review;
 import com.meong9.backend.domain.review.entity.ReviewFile;
 import com.meong9.backend.domain.review.entity.id.ReviewFileId;
@@ -31,4 +32,18 @@ public interface ReviewFileRepository extends JpaRepository<ReviewFile, ReviewFi
     WHERE rf.file.mediaFileId = :mediaFileId
 """)
     Optional<ReviewFile> findByMediaFileId(@Param("mediaFileId") Long mediaFileId);
+
+    @Query("""
+                SELECT new com.meong9.backend.domain.review.dto.FileResponseDto(
+                    rf.review.reviewId, 
+                    mf.fileType, 
+                    mf.fileSize, 
+                    mf.fileUrl, 
+                    mf.fileName
+                ) 
+                FROM ReviewFile rf 
+                JOIN rf.file mf 
+                WHERE rf.review.reviewId IN :reviewIds
+            """)
+    List<FileResponseDto> findMediaFilesByReviewIds(List<Long> reviewIds);
 }

--- a/backend/src/main/java/com/meong9/backend/domain/review/repository/ReviewRepository.java
+++ b/backend/src/main/java/com/meong9/backend/domain/review/repository/ReviewRepository.java
@@ -1,10 +1,10 @@
 package com.meong9.backend.domain.review.repository;
 
+import com.meong9.backend.domain.member.entity.Member;
+import com.meong9.backend.domain.review.dto.FileResponseDto;
 import com.meong9.backend.domain.review.dto.MyReviewResponseDto;
 import com.meong9.backend.domain.review.dto.PhotoReviewSummaryResponseDto;
-import com.meong9.backend.domain.member.entity.Member;
 import com.meong9.backend.domain.review.entity.Review;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -13,7 +13,6 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
-import java.util.Optional;
 
 @Repository
 public interface ReviewRepository extends JpaRepository<Review, Long> {
@@ -21,57 +20,86 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     List<Long> findPensionReviewCount(@Param("count") int count);
 
     @Query("""
-        SELECT DISTINCT r
-        FROM Review r
-        LEFT JOIN FETCH r.reviewFiles rf
-        LEFT JOIN FETCH rf.file
-        ORDER BY r.createdAt DESC LIMIT 10
-        """)
+            SELECT DISTINCT r
+            FROM Review r
+            LEFT JOIN FETCH r.reviewFiles rf
+            LEFT JOIN FETCH rf.file
+            ORDER BY r.createdAt DESC LIMIT 10
+            """)
     List<Review> findTop10RecentReviews();
 
-    @Query("SELECT new com.meong9.backend.domain.review.dto.MyReviewResponseDto(" +
-            "r.reviewId, r.content, r.score, r.visitDate, r.type, r.placePensionId, " +
-            "CASE WHEN r.type = '010' THEN p.name WHEN r.type = '020' THEN ps.name ELSE null END, r.nickname, " +
-            "new com.meong9.backend.domain.review.dto.FileResponseDto(mf.fileType, mf.fileSize, mf.fileUrl, mf.fileName)) " +
-            "FROM Review r " +
-            "LEFT JOIN r.reviewFiles rf " +
-            "LEFT JOIN rf.file mf " +
-            "LEFT JOIN Place p ON r.placePensionId = p.placeId AND r.type = '010' " +
-            "LEFT JOIN Pension ps ON r.placePensionId = ps.pensionId AND r.type = '020' " +
-            "WHERE r.member = :member ")
+    @Query("""
+                SELECT new com.meong9.backend.domain.review.dto.MyReviewResponseDto(
+                    r.reviewId, 
+                    r.content, 
+                    r.score, 
+                    r.visitDate, 
+                    r.type, 
+                    r.placePensionId, 
+                    CASE 
+                        WHEN r.type = '010' THEN p.name 
+                        WHEN r.type = '020' THEN ps.name 
+                        ELSE null 
+                    END, 
+                    r.nickname
+                ) 
+                FROM Review r 
+                LEFT JOIN Place p 
+                    ON r.placePensionId = p.placeId 
+                    AND r.type = '010' 
+                LEFT JOIN Pension ps 
+                    ON r.placePensionId = ps.pensionId 
+                    AND r.type = '020' 
+                WHERE r.member = :member
+            """)
     List<MyReviewResponseDto> findReviewsByMember(@Param("member") Member member);
 
     @Query("""
-    SELECT r FROM Review r
-    LEFT JOIN FETCH r.member m
-    LEFT JOIN FETCH m.profileImage pi
-    LEFT JOIN FETCH r.reviewFiles rf
-    LEFT JOIN FETCH rf.file f
-    WHERE r.placePensionId = :placeId AND r.type = :type
-    ORDER BY r.createdAt DESC
-    """)
+    SELECT new com.meong9.backend.domain.review.dto.FileResponseDto(
+        rf.review.reviewId, 
+        mf.fileType, 
+        mf.fileSize, 
+        mf.fileUrl, 
+        mf.fileName
+    ) 
+    FROM ReviewFile rf 
+    JOIN rf.file mf 
+    WHERE rf.review.reviewId IN :reviewIds
+""")
+    List<FileResponseDto> findFilesByReviewIds(@Param("reviewIds") List<Long> reviewIds);
+
+
+    @Query("""
+            SELECT r FROM Review r
+            LEFT JOIN FETCH r.member m
+            LEFT JOIN FETCH m.profileImage pi
+            LEFT JOIN FETCH r.reviewFiles rf
+            LEFT JOIN FETCH rf.file f
+            WHERE r.placePensionId = :placeId AND r.type = :type
+            ORDER BY r.createdAt DESC
+            """)
     List<Review> findReviewsByPlaceId(@Param("placeId") Long placeId, @Param("type") String type, Pageable pageable);
 
     @Query("""
-    SELECT new com.meong9.backend.domain.review.dto.PhotoReviewSummaryResponseDto(
-        r.reviewId,
-        MIN(rf.file.fileUrl),
-        COUNT(rf.file.fileUrl)
-    )
-    FROM Review r
-    JOIN r.reviewFiles rf
-    WHERE r.placePensionId = :placeId AND r.type = :type
-    GROUP BY r.reviewId
-    ORDER BY r.createdAt DESC
-""")
-    Slice<PhotoReviewSummaryResponseDto> findPhotoReviewSummaries( @Param("placeId") Long placeId,@Param("type") String type, Pageable pageable);
+                SELECT new com.meong9.backend.domain.review.dto.PhotoReviewSummaryResponseDto(
+                    r.reviewId,
+                    MIN(rf.file.fileUrl),
+                    COUNT(rf.file.fileUrl)
+                )
+                FROM Review r
+                JOIN r.reviewFiles rf
+                WHERE r.placePensionId = :placeId AND r.type = :type
+                GROUP BY r.reviewId
+                ORDER BY r.createdAt DESC
+            """)
+    Slice<PhotoReviewSummaryResponseDto> findPhotoReviewSummaries(@Param("placeId") Long placeId, @Param("type") String type, Pageable pageable);
 
     @Query("""
-    SELECT r
-    FROM Review r
-    WHERE r.type = :type AND r.placePensionId = :placePensionId
-    ORDER BY r.visitDate DESC
-""")
+                SELECT r
+                FROM Review r
+                WHERE r.type = :type AND r.placePensionId = :placePensionId
+                ORDER BY r.visitDate DESC
+            """)
     Slice<Review> findByTypeAndPlacePensionId(
             @Param("type") String type,
             @Param("placePensionId") Long placePensionId,

--- a/backend/src/main/java/com/meong9/backend/domain/review/service/ReviewService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/review/service/ReviewService.java
@@ -78,6 +78,10 @@ public class ReviewService {
     @Transactional(readOnly = true)
     public List<MyReviewResponseDto> getMyReviews(Member member) {
         List<MyReviewResponseDto> reviews = reviewRepository.findReviewsByMember(member);
+        List<Long> reviewIds = reviews.stream().map(MyReviewResponseDto::getReviewId).collect(Collectors.toList());
+        List<FileResponseDto> files = reviewFileRepository.findMediaFilesByReviewIds(reviewIds);
+        Map<Long, List<FileResponseDto>> fileMap = files.stream().collect(Collectors.groupingBy(FileResponseDto::getReviewId));
+        reviews.forEach(review -> review.setFile(fileMap.getOrDefault(review.getReviewId(), new ArrayList<>())));
         reviews.sort((r1, r2) -> Long.compare(r2.getReviewId(), r1.getReviewId()));
         
         return reviews;

--- a/backend/src/main/java/com/meong9/backend/domain/review/service/ReviewService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/review/service/ReviewService.java
@@ -41,7 +41,9 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.net.MalformedURLException;
 import java.net.URI;
+import java.net.URL;
 import java.nio.file.Paths;
 import java.text.DecimalFormat;
 import java.util.*;
@@ -329,7 +331,7 @@ public class ReviewService {
     }
 
     @Transactional
-    public void deleteReview(Long reviewId, Member member) throws IllegalAccessException {
+    public void deleteReview(Long reviewId, Member member) {
         // 리뷰 조회 및 권한 확인
         Review review = reviewRepository.findById(reviewId)
                 .orElseThrow(() -> new NotFoundException("리뷰"));
@@ -341,7 +343,8 @@ public class ReviewService {
         // 연관된 파일 삭제
         if (review.getReviewFiles() != null) {
             for (ReviewFile reviewFile : review.getReviewFiles()) {
-                mediaFileService.deleteFromS3(reviewFile.getFile().getFileKey());
+                String fileUrl = reviewFile.getFile().getFileUrl();
+                mediaFileService.deleteFromS3(extractFileKey(fileUrl));
                 reviewFile.getFile().delete(); // mediafile 소프트 삭제
             }
         }
@@ -362,6 +365,15 @@ public class ReviewService {
         }
 
         memberScoreService.deleteReview(member.getMemberId(), review.getPlacePensionId(), review.getScore(), review.getType());
+    }
+
+    private String extractFileKey(String fileUrl) {
+        try {
+            URL url = new URL(fileUrl);
+            return url.getPath().substring(1);
+        } catch (MalformedURLException e) {
+            throw new IllegalArgumentException("Invalid S3 URL: " + fileUrl, e);
+        }
     }
 
     // 최근 리뷰 10개 조회


### PR DESCRIPTION
## 📋 Summary
<!-- 이 PR에서 변경된 주요 내용을 간략히 작성해주세요. -->
- 내 후기 조회, 삭제 수정

## ✨ Feature Details
| Method | Path                      | Description      |
|--------|---------------------------|------------------|


## 💡 Key Considerations
<!-- 구현하면서 고려한 점, 또는 해결한 주요 이슈를 간단히 작성해주세요. -->
1. 내 후기 조회 시 mediafile 개수만큼 review가 조회되는 문제 해결
- review에 달린 mediafile이 n개일 시, review가 n개가 조회됨. 
- 이를 해결하기 위해서 review와 mediafile을 찾는 쿼리를 분리하고 애플리케이션 단에서 reviewId를 기준으로 매핑하도록 함. 
3. 후기 저장 로직 변경으로 인한 삭제 로직 수정


## ✅ Checklist
- [ ] 코드를 스스로 검토했나요?
- [ ] 필요한 테스트를 추가하고 모두 통과했나요?
- [ ] 브랜치 전략에 맞는 브랜치에 PR을 올렸나요?
- [ ] 커밋 메시지가 컨벤션에 맞나요?
- [ ] 필요한 문서를 업데이트했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - 리뷰에 다수의 미디어 파일 첨부가 가능해져, 보다 풍부한 리뷰 경험을 제공합니다.
  - 사용자 리뷰 조회 시 첨부된 미디어 파일이 올바르게 표시되도록 개선되었습니다.

- **Refactor**
  - 리뷰 업데이트 및 삭제 과정의 오류 처리 방식이 단순화되어, 시스템 안정성이 향상되었습니다.
  - 미디어 파일 삭제와 관련된 내부 처리 로직이 최적화되어 전반적인 리뷰 관리 효율이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->