### PR TITLE
fix: 오후 3시 알람으로 스케줄러 수정

### DIFF
--- a/backend/src/main/java/com/meong9/backend/domain/alarm/service/FcmService.java
+++ b/backend/src/main/java/com/meong9/backend/domain/alarm/service/FcmService.java
@@ -44,8 +44,8 @@ public class FcmService {
     private String aesKey;
 
     // 매일 오후 3시에 FCM 알람
-//    @Scheduled(cron = "0 0 15 * * ?") // 매일 오후 3시에 실행
-    @Scheduled(cron = "0 * * * * ?")
+    @Scheduled(cron = "0 0 15 * * ?") // 매일 오후 3시에 실행
+//    @Scheduled(cron = "0 * * * * ?")
     @Transactional
     public void sendAnniversaryNotifications() {
         Set<String> tokenKeys = getAllTokensUsingScan();


### PR DESCRIPTION
## 📋 Summary
<!-- 이 PR에서 변경된 주요 내용을 간략히 작성해주세요. -->
1분마다 알람 오게 해서 잘 오는 것 확인 후 변경함~
백그라운드 알람이라 웹 켜놓고 해당 페이지에 있으면 알람 안옴
(서비스 이용하는 중에는 서비스 들어오게 하는 홍보 멘트? 안뜨게 하기 위해)

## ✨ Feature Details
| Method | Path                      | Description      |
|--------|---------------------------|------------------|


## 💡 Key Considerations
<!-- 구현하면서 고려한 점, 또는 해결한 주요 이슈를 간단히 작성해주세요. -->


## ✅ Checklist
- [ ] 코드를 스스로 검토했나요?
- [ ] 필요한 테스트를 추가하고 모두 통과했나요?
- [ ] 브랜치 전략에 맞는 브랜치에 PR을 올렸나요?
- [ ] 커밋 메시지가 컨벤션에 맞나요?
- [ ] 필요한 문서를 업데이트했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- 기념일 알림의 전송 스케줄이 매분에서 매일 오후 3시로 조정되었습니다. 이는 알림 전달 빈도 및 사용자 경험에 직접적인 영향을 미칩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->